### PR TITLE
Fix for JENKINS-9462

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -296,7 +296,7 @@ class EmulatorConfig implements Serializable {
 
         // List available snapshots for this emulator
         ByteArrayOutputStream listOutput = new ByteArrayOutputStream();
-        String args = String.format("-snapshot-list -avd %s", getAvdName());
+        String args = String.format((showWindow ? "" : "-no-window ") + "-snapshot-list -avd %s", getAvdName());
         Utils.runAndroidTool(launcher, listOutput, logger, androidSdk, Tool.EMULATOR, args, null);
 
         // Check whether a Jenkins snapshot was listed in the output


### PR DESCRIPTION
fixes JENKINS-9462 by adding the '-no-window' flag when listing snapshots if the plugin is configured to not show a window.
