### PR TITLE
JENKINS-10785 failure to terminate logcat reading for android emulator

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -531,10 +531,15 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
 
         // Clean up logging process
         if (logcatProcess != null) {
-            if (killed && logcatProcess.isAlive()) {
+            if (logcatProcess.isAlive()) {
                 // This should have stopped when the emulator was,
                 // but if not attempt to kill the process manually
-                logcatProcess.kill();
+                // Give the logcat process a final chance to finish
+                Thread.sleep(5 * 1000);
+                if (logcatProcess.isAlive()) {
+                    // Still alive make sure process is killed
+                    logcatProcess.kill();
+                }
             }
             try {
                 logcatStream.close();


### PR DESCRIPTION
I have been running with these patched applied for a couple of weeks without seeing any adverse effects and also without seeing a failure to terminate the logcat readers.
