### PR TITLE
[FIXED JENKINS-11015] Caught exception evaluationg: item.getCauseOfBlocka

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -210,12 +210,20 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
             return null;
         }
 
+        EmulatorConfig emuConfig;
+        try {
+            emuConfig = EmulatorConfig.create(avdName, osVersion, screenDensity,
+                screenResolution, deviceLocale, sdCardSize, wipeData, showWindow, useSnapshots,
+                commandLineOptions);
+        } catch (IllegalArgumentException e) {
+            log(logger, Messages.EMULATOR_CONFIGURATION_BAD(e.getLocalizedMessage()));
+            build.setResult(Result.NOT_BUILT);
+            return null;
+        }
+
         // Ok, everything looks good.. let's go
         String displayHome = androidSdk.hasKnownRoot() ? androidSdk.getSdkRoot() : Messages.USING_PATH();
         log(logger, Messages.USING_SDK(displayHome));
-        EmulatorConfig emuConfig = EmulatorConfig.create(avdName, osVersion, screenDensity,
-                screenResolution, deviceLocale, sdCardSize, wipeData, showWindow, useSnapshots,
-                commandLineOptions);
 
         return doSetUp(build, launcher, listener, androidSdk, emuConfig, expandedProperties);
     }

--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -75,8 +75,20 @@ class EmulatorConfig implements Serializable {
         }
 
         this.osVersion = AndroidPlatform.valueOf(osVersion);
+        if (this.osVersion == null) {
+            throw new IllegalArgumentException(
+                    "OS version not recognised: " + osVersion);
+        }
         this.screenDensity = ScreenDensity.valueOf(screenDensity);
+        if (this.screenDensity == null) {
+            throw new IllegalArgumentException(
+                    "Screen density not recognised: " + screenDensity);
+        }
         this.screenResolution = ScreenResolution.valueOf(screenResolution);
+        if (this.screenResolution == null) {
+            throw new IllegalArgumentException(
+                    "Screen resolution not recognised: " + screenResolution);
+        }
         this.deviceLocale = deviceLocale;
         this.sdCardSize = sdCardSize;
         this.wipeData = wipeData;

--- a/src/main/resources/hudson/plugins/android_emulator/Messages.properties
+++ b/src/main/resources/hudson/plugins/android_emulator/Messages.properties
@@ -19,6 +19,7 @@ DEFAULT_LOCALE_WARNING=Locale will default to ''{0}'' if not specified
 LOCALE_FORMAT_WARNING=Locale should have format: ab_XY
 INVALID_SD_CARD_SIZE=SD card size should be numeric with suffix, e.g. 32M
 SD_CARD_SIZE_TOO_SMALL=SD card size must be at least 9 megabytes
+EMULATOR_CONFIGURATION_BAD=Unrecognised Android emulator configuration: ''{0}''
 
 # Emulator creation
 AVD_DOES_NOT_EXIST=Could not start AVD ''{0}'', as it could not be found at ''{1}''


### PR DESCRIPTION
[FIXED JENKINS-11015] Caught exception evaluationg: item.getCauseOfBlockage().

Trap invalid emulator parameters and ensure that getAvdName() will not fail
with a NullPointerException.

Note that the parameter checks in DescriptorImpl in AndroidEmulator.java use a slightly different means of checking screen resolutions. It might be worth unifying things a little to use the valueOf methods for density, resolution etc. so that values are accepted consistently. I'll take a look at this when time allows.
