### PR TITLE
JENKINS-11492 android emulator logcat temporary file breaks maven-release

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -367,7 +367,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
 
         // Start dumping logs to disk
         final File artifactsDir = build.getArtifactsDir();
-        final FilePath logcatFile = build.getWorkspace().createTempFile("logcat_", ".log");
+        final FilePath logcatFile = build.getWorkspace().createTextTempFile("logcat_", ".log", "", false);
         final OutputStream logcatStream = logcatFile.write();
         final String logcatArgs = String.format("-s %s logcat -v time", serial);
         ArgumentListBuilder logcatCmd = Utils.getToolCommand(androidSdk, isUnix, Tool.ADB, logcatArgs);


### PR DESCRIPTION
JENKINS-11492 android emulator logcat temporary file breaks maven-release-plugin

Use createTextTempFile to allocate the temporary file. Force the temporary
file to be created in the java.io.tmpdir directory instead of the job
workspace by passing parameter isThisDirectory as false.
