### PR TITLE
Allow user to specify target abi / system image

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/Constants.java
+++ b/src/main/java/hudson/plugins/android_emulator/Constants.java
@@ -28,6 +28,11 @@ public interface Constants {
         "hw.touchScreen", "hw.trackBall", "vm.heapSize"
     };
 
+    /** Possible abis */
+    static final String[] TARGET_ABIS = {
+        "armeabi", "armeabi-v7a", "x86", "mips"
+    };
+
     /** Name of the snapshot image we will use. */
     static final String SNAPSHOT_NAME = "jenkins";
 

--- a/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
@@ -3,7 +3,7 @@
   <f:block>
     <table style="margin-left:2em">
 
-      <f:radioBlock name="android-emulator.useNamed" value="true" 
+      <f:radioBlock name="android-emulator.useNamed" value="true"
           title="${%Run existing emulator}" checked="${instance.useNamedEmulator}"
           help="${resURL}/plugin/android-emulator/help-emulatorNamed.html">
         <f:block>
@@ -72,6 +72,11 @@
               </f:repeatable>
             </f:entry>
 
+            <f:entry title="${%Target ABI}" help="${resURL}/plugin/android-emulator/help-targetAbi.html">
+                <f:editableComboBox id="android-emulator.targetAbi" field="targetAbi"
+                                    items="${descriptor.targetAbis}"
+                                    checkUrl="'descriptorByName/AndroidEmulator/checkTargetAbi?value='+escape(this.value)" />
+            </f:entry>
           </table>
         </f:block>
       </f:radioBlock>

--- a/src/main/resources/hudson/plugins/android_emulator/Messages.properties
+++ b/src/main/resources/hudson/plugins/android_emulator/Messages.properties
@@ -20,6 +20,7 @@ SUSPECT_RESOLUTION_ANDROID_4=That doesn''t look right for Android {0}. Did you m
 DEFAULT_LOCALE_WARNING=Locale will default to ''{0}'' if not specified
 LOCALE_FORMAT_WARNING=Locale should have format: ab_XY
 INVALID_SD_CARD_SIZE=SD card size should be numeric with suffix, e.g. 32M
+INVALID_TARGET_ABI=Invalid target abi
 SD_CARD_SIZE_TOO_SMALL=SD card size must be at least 9 megabytes
 EMULATOR_CONFIGURATION_BAD=Unrecognised Android emulator configuration: ''{0}''
 
@@ -48,6 +49,7 @@ SDK_NOT_SPECIFIED=Android SDK directory needs to be specified in order to create
 SDK_NOT_FOUND=Cannot find Android SDK at ''{0}''
 INVALID_AVD_TARGET=The desired AVD platform ''{0}'' is not installed on this machine
 ABI_REQUIRED=The desired platform ''{0}'' requires that you install a system image in order to create an AVD.\nUse the Android SDK Manager to install the ''ARM EABI v7a System Image'' for this platform.
+MORE_THAN_ONE_ABI=There is more than one system image defined for platform ''{0}''.\nPick an image to use and set it in the ''Target ABI'' config field.\n{1}.
 AVD_CREATION_FAILED=Failed to run AVD creation command
 AVD_CREATION_ABORTED=AVD creation command failed to complete normally
 AVD_CREATION_INTERRUPTED=Interrupted while creating new emulator

--- a/src/main/webapp/help-targetAbi.html
+++ b/src/main/webapp/help-targetAbi.html
@@ -1,0 +1,3 @@
+Should be the name of the abi / system image to be used, e.g "<code>armeabi</code>" or "<code>x86</code>".<br/>
+If empty the default abi for the select platform will be used. You only need to define this field if you have
+more than one system image per Android platform installed.


### PR DESCRIPTION
For some versions of Android there is more than one available
system image / ABI. When more than one image is installed,
the user needs to specify which version is to be used.
