### PR TITLE
Get rid of the redundant 'isUnix' flag

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -257,12 +257,11 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
             final EmulatorConfig emuConfig, final HardwareProperty[] hardwareProperties)
                 throws IOException, InterruptedException {
         final PrintStream logger = listener.getLogger();
-        final boolean isUnix = launcher.isUnix();
 
         // First ensure that emulator exists
         final boolean emulatorAlreadyExists;
         try {
-            Callable<Boolean, AndroidEmulatorException> task = emuConfig.getEmulatorCreationTask(androidSdk, isUnix, listener);
+            Callable<Boolean, AndroidEmulatorException> task = emuConfig.getEmulatorCreationTask(androidSdk, listener);
             emulatorAlreadyExists = launcher.getChannel().call(task);
         } catch (EmulatorDiscoveryException ex) {
             log(logger, Messages.CANNOT_START_EMULATOR(ex.getMessage()));
@@ -276,7 +275,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
 
         // Update emulator configuration with desired hardware properties
         if (!emuConfig.isNamedEmulator() && hardwareProperties.length != 0) {
-            Callable<Void, IOException> task = emuConfig.getEmulatorConfigTask(hardwareProperties, isUnix, listener);
+            Callable<Void, IOException> task = emuConfig.getEmulatorConfigTask(hardwareProperties, listener);
             launcher.getChannel().call(task);
         }
 
@@ -612,7 +611,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
         if (deleteAfterBuild) {
             try {
                 Callable<Boolean, Exception> deletionTask = emulatorConfig.getEmulatorDeletionTask(
-                		emu.launcher().isUnix(), emu.launcher().getListener());
+                        emu.launcher().getListener());
                 emu.launcher().getChannel().call(deletionTask);
             } catch (Exception ex) {
                 log(emu.logger(), Messages.FAILED_TO_DELETE_AVD(ex.getLocalizedMessage()));

--- a/src/main/java/hudson/plugins/android_emulator/util/Utils.java
+++ b/src/main/java/hudson/plugins/android_emulator/util/Utils.java
@@ -3,6 +3,7 @@ package hudson.plugins.android_emulator.util;
 import static hudson.plugins.android_emulator.AndroidEmulator.log;
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.Functions;
 import hudson.Launcher;
 import hudson.Proc;
 import hudson.Util;
@@ -279,16 +280,15 @@ public class Utils {
     /**
      * Locates the current user's home directory using the same scheme as the Android SDK does.
      *
-     * @param isUnix Whether the system where this command should run is sane.
      * @return A {@link File} representing the directory in which the ".android" subdirectory should go.
      */
-    public static File getHomeDirectory(String androidSdkHome, boolean isUnix) {
+    public static File getHomeDirectory(String androidSdkHome) {
         // From git://android.git.kernel.org/platform/external/qemu.git/android/utils/bufprint.c
         String homeDirPath = System.getenv("ANDROID_SDK_HOME");
         if (homeDirPath == null) {
             if (androidSdkHome != null) {
                 homeDirPath = androidSdkHome;
-            } else if (isUnix) {
+            } else if (!Functions.isWindows()) {
                 homeDirPath = System.getenv("HOME");
                 if (homeDirPath == null) {
                     homeDirPath = "/tmp";


### PR DESCRIPTION
In relation to a531f90453e25378efc5a1b1e15b55a99c25f709, I noticed that
the way the 'isUnix' flag is used is mostly redundant. It's computed by
the master and then passed with a closure to be exected on the slave.

But once your code starts to execute on the slave, its JVM already knows
what platform it is running on. So it's more concise and faster not to
pass around this flag from the master.

Similarly, when a method signature returns a File, like
Utils.getHomeDirectory(), then you are by definition already executing
on the target JVM, so these functions shouldn't take the 'isUnix'
parameter. It's concise, faster, and less error prone to just let this
function computes whether it's running on an Unix or not.

This commit eliminates those redundant uses of the 'isUnix' flag from
the signature.

I don't know if other plugins started depending on these signatures,
and/or if you'd like to maintain API compatibility, so I'm sending this
in as a pull request. Please feel free to disregard if that is the case.
