### PR TITLE
Don't look for specific emulator binaries.

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/sdk/Tool.java
+++ b/src/main/java/hudson/plugins/android_emulator/sdk/Tool.java
@@ -18,6 +18,10 @@ public enum Tool {
            EMULATOR64_ARM, EMULATOR64_MIPS, EMULATOR64_X86
     };
 
+    public static Tool[] REQUIRED = new Tool[] {
+          AAPT, ADB, ANDROID, EMULATOR, MKSDCARD
+    };
+
     public final String executable;
     public final String windowsExtension;
     public final boolean isPlatformTool;
@@ -43,8 +47,15 @@ public enum Tool {
         return executable + windowsExtension;
     }
 
+    public static String[] getAllRequiredExecutableVariants() {
+        return getAllExecutableVariants(REQUIRED);
+    }
+
     public static String[] getAllExecutableVariants() {
-        final Tool[] tools = values();
+        return getAllExecutableVariants(values());
+    }
+
+    private static String[] getAllExecutableVariants(final Tool[] tools) {
         String[] executables = new String[tools.length * 2];
         for (int i = 0, n = tools.length; i < n; i++) {
             executables[i*2] = tools[i].getExecutable(true);

--- a/src/main/java/hudson/plugins/android_emulator/util/Utils.java
+++ b/src/main/java/hudson/plugins/android_emulator/util/Utils.java
@@ -246,7 +246,7 @@ public class Utils {
 
         // Search the possible tool directories to ensure the tools exist
         int toolsFound = 0;
-        int expectedToolCount = Tool.values().length;
+        int expectedToolCount = Tool.REQUIRED.length;
         if (!new File(sdkRoot, "platform-tools").exists()) {
             // aapt doesn't exist in "tools" until SDK Tools r9
             expectedToolCount--;
@@ -257,7 +257,7 @@ public class Utils {
             if (!toolsDir.isDirectory()) {
                 continue;
             }
-            for (String executable : Tool.getAllExecutableVariants()) {
+            for (String executable : Tool.getAllRequiredExecutableVariants()) {
                 File toolPath = new File(toolsDir, executable);
                 if (toolPath.exists() && toolPath.isFile()) {
                     toolsFound++;


### PR DESCRIPTION
Only look for the main emulator binary when validating an SDK root -
don't look for the emulator64-\* binaries (only in r21+) and the -mips
and -x86 binaries (only in r12+).

This resolves JENKINS-15967.
