### PR TITLE
fix JENKINS-14901

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
@@ -126,7 +126,7 @@ public class AndroidEmulatorContext {
 	 */
 	public ProcStarter getProcStarter(ArgumentListBuilder command)
 			throws IOException, InterruptedException {
-		return getProcStarter().cmds(command);
+		return getProcStarter().cmds(command).envs("LD_LIBRARY_PATH=" + sdk.getSdkRoot() + "/tools/lib");
 	}
 
         /**


### PR DESCRIPTION
failure to launch emulator seems to be caused on my infra (cloudbees) by 64 vs 32bits libraries used to run emulator process. Setting LD_LIBRARY_PATH to use android SDK provided libs fixes the issue
