### PR TITLE
Don't use /tmp in tests

### DIFF
--- a/src/test/java/hudson/plugins/android_emulator/util/UtilsTest.java
+++ b/src/test/java/hudson/plugins/android_emulator/util/UtilsTest.java
@@ -48,7 +48,7 @@ public class UtilsTest extends TestCase {
     }
 
     public void testRelativePathNothingInCommon() {
-        assertRelative("/a/b/c", "/tmp/foo/bar/baz", "../../../tmp/foo/bar/baz/");
+        assertRelative("/a/b/c", "/d/e/f/g", "../../../d/e/f/g/");
     }
 
     public void testRelativeRoot() {


### PR DESCRIPTION
Apparently on a mac, `getCanonicalPath` resolves `/tmp` to `/private/tmp`, causing
this test to fail. I've replaced the example with something semantically
equivalent for testing purposes, but it will actually succeed when building
on OSX.

Before:

```
Results :

Failed tests:   testRelativePathNothingInCommon(hudson.plugins.android_emulator.util.UtilsTest): expected:<../../../[]tmp/foo/bar/baz/> but was:<../../../[private/]tmp/foo/bar/baz/>

Tests run: 47, Failures: 1, Errors: 0, Skipped: 0
```

After:

```
Results :

Tests run: 47, Failures: 0, Errors: 0, Skipped: 0
```
