### PR TITLE
[FIXED JENKINS-18970] Fixed bug in Windows environment.

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/util/Utils.java
+++ b/src/main/java/hudson/plugins/android_emulator/util/Utils.java
@@ -604,7 +604,6 @@ public class Utils {
         if (fromPath.equals(toPath)) {
             return "";
         }
-
         // Target directory is a subdirectory
         if (toPath.startsWith(fromPath)) {
             int fromLength = fromPath.length();
@@ -612,10 +611,14 @@ public class Utils {
             return toPath.substring(index) + File.separatorChar;
         }
 
+        // bugfix for JENKINS-18970. In Windows environment, File separator
+        // can not be used as a Pattern regex.
+        // by aitorTheRed
+        String separator = Pattern.quote(File.separator);
         // Target directory is somewhere above our directory
-        String[] fromParts = fromPath.substring(1).split(File.separator);
+        String[] fromParts = fromPath.substring(1).split(separator);
         final int fromLength = fromParts.length;
-        String[] toParts = toPath.substring(1).split(File.separator);
+        String[] toParts = toPath.substring(1).split(separator);
         final int toLength = toParts.length;
 
         // Find the number of common path segments


### PR DESCRIPTION
Fixed bug [JENKINS-18970]. The origin was the use of File.separator in String.split functions in util/Utils.java:616, which relays on Pattern.compile. In windows, File.separator provides a String which is an invalid regex expresion. By the use of Pattern.quote() function, the problem is solved.
