### PR TITLE
[FIXED JENKINS-12821] android.device=emulator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jvnet.hudson.plugins</groupId>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>port-allocator</artifactId>
-      <version>1.5</version>
+      <version>1.8</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
@@ -48,11 +48,14 @@ public class AndroidEmulatorContext {
 
 		// Use the Port Allocator plugin to reserve the two ports we need
 		portAllocator = PortAllocationManager.getManager(computer);
-		userPort = portAllocator.allocateRandom(build, 0);
-		adbPort = portAllocator.allocateRandom(build, 0);
-		adbServerPort = portAllocator.allocateRandom(build, 0);
+		final int PORT_RANGE_START = 5560;
+		final int PORT_RANGE_END = 5900;
+		int[] ports = portAllocator.allocatePortRange(build, PORT_RANGE_START, PORT_RANGE_END, 3, true);
+		userPort = ports[0];
+		adbPort = ports[1];
+		adbServerPort = ports[2];
 
-		serial = "localhost:" + adbPort;
+		serial = "emulator-" + userPort;
 	}
 
 	public void cleanUp() {


### PR DESCRIPTION
The android emulator does not connect to ADB properly if used with
a non-4 digit port number

Update to port-allocator 1.8. This allows us to use the new allocatePortRange method. We allocate a group of 3 consecutive ports in the 4 digit port number range and hence work around the bug. Note that the two emulator ports should be consecutive numbers.

Tested on Ubuntu 12.04 with android-maven-plugin. Use -Dandroid.device=emulator to select the emulator.
