### PR TITLE
[FIXED JENKINS-21280] Update usage statistics opt out

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/SdkInstaller.java
+++ b/src/main/java/hudson/plugins/android_emulator/SdkInstaller.java
@@ -530,6 +530,7 @@ public class SdkInstaller {
             try {
                 out = new PrintWriter(configFile);
                 out.println("pingOptIn=false");
+                out.println("pingId=0");
                 out.flush();
                 out.close();
             } catch (FileNotFoundException e) {


### PR DESCRIPTION
Empirically, emulator version 22.3.0 installed via Android Studio 0.4.0
requires pingId=... to opt out. pingOptIn=false, as previously
implemented is not sufficient.
