### PR TITLE
increase-emulator-start-time-limit: Increase limit from 180s to 360s

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -60,7 +60,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
     private static final int ADB_CONNECT_TIMEOUT_MS = 60 * 1000;
 
     /** Duration by which emulator booting should normally complete. */
-    private static final int BOOT_COMPLETE_TIMEOUT_MS = 180 * 1000;
+    private static final int BOOT_COMPLETE_TIMEOUT_MS = 360 * 1000;
 
     /** Interval during which killing a process should complete. */
     private static final int KILL_PROCESS_TIMEOUT_MS = 10 * 1000;
@@ -382,7 +382,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
         log(logger, Messages.WAITING_FOR_BOOT_COMPLETION());
         int bootTimeout = BOOT_COMPLETE_TIMEOUT_MS;
         if (!emulatorAlreadyExists || emuConfig.shouldWipeData() || snapshotState == SnapshotState.INITIALISE) {
-            bootTimeout *= 4;
+            bootTimeout *= 2;
         }
         boolean bootSucceeded = waitForBootCompletion(ignoreProcess, bootTimeout, emu);
         if (!bootSucceeded) {


### PR DESCRIPTION
I'm submitting this for feedback, but not necessarily for merging as is.

The emulator sometimes takes more than 180 seconds, the hard coded time
limit([1](https://github.com/jenkinsci/android-emulator-plugin/blob/9b91a1bb1c99be0b5371f0ada2992bd6ed51d503/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java#L63))([2](https://github.com/jenkinsci/android-emulator-plugin/blob/9b91a1bb1c99be0b5371f0ada2992bd6ed51d503/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java#L381)), to be ready, when starting from a snapshot.

The plugin increases the time limit by a factor of 4 when it's not using
a snapshot.

I saw the non-snapshot scenario take between 400 and 500 seconds to get
the emulator ready.

I increased the time limit to 360 s, and reduced the factor from 4 to 2.
