### PR TITLE
[FIXED JENKINS-22334] Use "emulator-" instead of "localhost-"

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
@@ -52,7 +52,7 @@ public class AndroidEmulatorContext {
 		adbPort = portAllocator.allocateRandom(build, 0);
 		adbServerPort = portAllocator.allocateRandom(build, 0);
 
-		serial = "localhost:" + adbPort;
+		serial = "emulator-" + (adbPort - 1);
 	}
 
 	public void cleanUp() {


### PR DESCRIPTION
- This fixes a bug with recent versions of the Android SDK-tools which would cause the test runner to crash before running any tests
- Proven to work on a local Jenkins instance with both Ant & Gradle plugins
  - Jenkins ver. 1.560 / Jenkins Gradle plugin 1.23 / Ant Plugin 1.2
  - Android SDK Tools 22.6.2 / Android SDK Build-tools 19.0.3
- Updated AndroidEmulatorContext.java
