### PR TITLE
Fix naming of emulator images for x86-based Google APIs.

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -147,7 +147,7 @@ class EmulatorConfig implements Serializable {
         String locale = getDeviceLocale().replace('_', '-');
         String density = screenDensity.toString();
         String resolution = screenResolution.toString();
-        String platform = osVersion.getTargetName().replace(':', '_').replace(' ', '_');
+        String platform = osVersion.getTargetName().replaceAll("[^a-zA-Z0-9._-]", "_");
         String abi = "";
         if (targetAbi != null && osVersion.requiresAbi()) {
             abi = "_" + targetAbi.replace(' ', '-');


### PR DESCRIPTION
An emulator for the API "Google Inc.:Google APIs (x86 System Image):19" could not be created because of the round brackets. This patch fixes the issue.
