### PR TITLE
Jenkins 11952 debug

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -706,11 +706,17 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
 
         final String args = String.format("-s %s shell getprop dev.bootcomplete", emu.serial());
         ArgumentListBuilder bootCheckCmd = emu.getToolCommand(Tool.ADB, args);
+        ArgumentListBuilder bootDbgCmd = emu.getToolCommand(Tool.ADB, "devices -l");
 
         try {
             final long adbTimeout = timeout / 8;
             int iterations = 0;
             while (System.currentTimeMillis() < start + timeout && (ignoreProcess || emu.process().isAlive())) {
+                Proc procDbg = emu.getProcStarter(bootDbgCmd).stdout(emu.logger()).start();
+                int retValDbg = procDbg.joinWithTimeout(adbTimeout, TimeUnit.MILLISECONDS, emu.launcher().getListener());
+                if (retValDbg == 0) {
+                    log(emu.logger(), "adb devices returned " + retValDbg);
+                }
                 ByteArrayOutputStream stream = new ByteArrayOutputStream(4);
 
                 // Run "getprop", timing-out in case adb hangs

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -303,6 +303,8 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
         // allowing them to complete faster.
         Proc adbStart = emu.getToolProcStarter(Tool.ADB, "start-server").stdout(logger).start();
         adbStart.joinWithTimeout(5L, TimeUnit.SECONDS, listener);
+        Proc adbStart2 = emu.getToolProcStarter(Tool.ADB, "start-server").stdout(logger).start();
+        adbStart2.joinWithTimeout(5L, TimeUnit.SECONDS, listener);
 
         // Determine whether we need to create the first snapshot
         final SnapshotState snapshotState;

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -302,6 +302,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
         // We manually start the adb-server so that later commands will not have to start it,
         // allowing them to complete faster.
         Proc adbStart = emu.getToolProcStarter(Tool.ADB, "start-server").stdout(logger).start();
+        adbStart.joinWithTimeout(5L, TimeUnit.SECONDS, listener);
 
         // Determine whether we need to create the first snapshot
         final SnapshotState snapshotState;
@@ -347,7 +348,6 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
 
         // Give the emulator process a chance to initialise
         Thread.sleep(5 * 1000);
-        adbStart.joinWithTimeout(5L, TimeUnit.SECONDS, listener);
 
         // Check whether a failure was reported on stdout
         if (emulatorOutput.toString().contains("image is used by another emulator")) {

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -390,6 +390,16 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
             bootTimeout *= 2;
         }
         boolean bootSucceeded = waitForBootCompletion(ignoreProcess, bootTimeout, emu);
+
+        // Start dumping logcat to temporary file
+        // Note we capture even if boot failed because there may be some debug information
+        // in there!
+        final File artifactsDir = build.getArtifactsDir();
+        final FilePath logcatFile = build.getWorkspace().createTextTempFile("logcat_", ".log", "", false);
+        final OutputStream logcatStream = logcatFile.write();
+        final String logcatArgs = String.format("-s %s logcat -v time", emu.serial());
+        final Proc logWriter = emu.getToolProcStarter(Tool.ADB, logcatArgs).stdout(logcatStream).stderr(new NullStream()).start();
+
         if (!bootSucceeded) {
             if ((System.currentTimeMillis() - bootTime) < bootTimeout) {
                 log(logger, Messages.EMULATOR_STOPPED_DURING_BOOT());
@@ -397,16 +407,11 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
                 log(logger, Messages.BOOT_COMPLETION_TIMED_OUT(bootTimeout / 1000));
             }
             build.setResult(Result.NOT_BUILT);
-            cleanUp(emuConfig, emu);
+            // Give logcat some time to work its magic before cleaning up
+            Thread.sleep(3 * 1000);
+            cleanUp(emuConfig, emu, logWriter, logcatFile, logcatStream, artifactsDir);
             return null;
         }
-
-        // Start dumping logcat to temporary file
-        final File artifactsDir = build.getArtifactsDir();
-        final FilePath logcatFile = build.getWorkspace().createTextTempFile("logcat_", ".log", "", false);
-        final OutputStream logcatStream = logcatFile.write();
-        final String logcatArgs = String.format("-s %s logcat -v time", emu.serial());
-        final Proc logWriter = emu.getToolProcStarter(Tool.ADB, logcatArgs).stdout(logcatStream).stderr(new NullStream()).start();
 
         // Unlock emulator by pressing the Menu key once, if required.
         // Upon first boot (and when the data is wiped) the emulator is already unlocked


### PR DESCRIPTION
NOT INTENDED FOR MERGING - just wanting a CI built version of the plugin for others to test with.

List connected adb devices whilst waiting for bootcomplete.
This should give us some better clues as to what is going on.

The interesting output that you will see in the console logs is as follows (the exact details will vary)

    $ /opt/android/android-sdk-20-linux_x86/platform-tools/adb connect emulator-5607
    [android] Waiting for emulator to finish booting...
    $ /opt/android/android-sdk-20-linux_x86/platform-tools/adb devices -l
    List of devices attached 
    emulator-5607          offline
    
    [android] adb devices returned 0
    $ /opt/android/android-sdk-20-linux_x86/platform-tools/adb -s emulator-5607 shell getprop dev.bootcomplete
    error: device offline
