### PR TITLE
BugFix: Custom hardware properties on Windows

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/util/Utils.java
+++ b/src/main/java/hudson/plugins/android_emulator/util/Utils.java
@@ -433,10 +433,9 @@ public class Utils {
      * @throws IOException If the file could not be read.
      */
     public static Map<String, String> parseConfigFile(File configFile) throws IOException {
-        FileReader fileReader = new FileReader(configFile);
-        BufferedReader reader = new BufferedReader(fileReader);
+        String configFileContent = FileUtils.readFileToString(configFile);
         Properties properties = new Properties();
-        properties.load(reader);
+        properties.load(new StringReader(configFileContent.replace("\\","\\\\"));
         reader.close();
 
         final Map<String, String> values = new HashMap<String, String>();


### PR DESCRIPTION
Re-writing default AVD config files result in missing backslashes
Resulting in error's such as: 
- emulator: ERROR: This AVD's configuration is missing a kernel file!!

Properties.load will remove single backslashes. But doubling them beforehand is a dirty workaround ... for now.
http://stackoverflow.com/questions/5784895/java-properties-backslash
