### PR TITLE
Fix naming of emulator images for new targetAbis

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -150,7 +150,7 @@ class EmulatorConfig implements Serializable {
         String platform = osVersion.getTargetName().replaceAll("[^a-zA-Z0-9._-]", "_");
         String abi = "";
         if (targetAbi != null && osVersion.requiresAbi()) {
-            abi = "_" + targetAbi.replace(' ', '-').replace('_', '-');
+            abi = "_" + targetAbi.replaceAll("[^a-zA-Z0-9._-]", "-");
         }
         String suffix = "";
         if (avdNameSuffix != null) {


### PR DESCRIPTION
Hi,

It is currently not possible to create Android Wear, Android TV, nor Android 5.0 with Google APIs emulator images with the plugin.

Previously, Tag/ABIs were either
* armeabi
* armeabi-v7a
* x86
* x86_64
* mips

Google seems to have adopted a new convention on targets, now it can also be (for example) :
* android-wear/armeabi-v7a (for Android Wear)
* google_apis/x86_64 (For 5.0 with Google APIs)
* android-tv/x86 (for Android TV)

Since the Target ABI is appended to the emulator file name, the plugin now tries to create files with forward slashes...
`Error: AVD name 'hudson_fr-FR_480_1080x1920_Google_Inc._Google_APIs_21_google-apis/armeabi-v7a' contains invalid characters.`

My commit replaces all the non alpha-numerial characters of the targetAbi to dashes.

If you are able, please merge this fix quickly, and deploy a new version of the plugin, as it impacts all the Android developers who want to run their tests on the latest versions of the OS :(

Merry christmas and happy new year !

Louis