### PR TITLE
Adds option to run monkey on multiple packages.

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyBuilder.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Random;
 
 import net.sf.json.JSONObject;
@@ -78,10 +79,22 @@ public class MonkeyBuilder extends AbstractBuilder {
 
         // Set up arguments to adb
         final String deviceIdentifier = getDeviceIdentifier(build, listener);
-        final String expandedPackageId = Utils.expandVariables(build, listener, this.packageId);
+        log(logger, String.format("PACKAGE ID: %s", this.packageId));
+        StringBuilder packageArgs = new StringBuilder();
+        StringBuilder packageNamesLog = new StringBuilder(); // For logging
+        if(!this.packageId.equals("")) {
+        	for(String s : this.packageId.split(" ")) {
+        		// Add "-p [packagename]"
+        		packageArgs.append(" -p ");
+        		String expandedPackageId = Utils.expandVariables(build, listener, s);
+        		packageArgs.append(expandedPackageId);
+        		packageNamesLog.append(expandedPackageId);
+        	}
+        }
         final long seedValue = parseSeed(seed);
-        String args = String.format("%s shell monkey -v -v -p %s -s %d --throttle %d %d",
-                deviceIdentifier, expandedPackageId, seedValue, throttleMs, eventCount);
+        String args = String.format("%s shell monkey -v -v %s -s %d --throttle %d %d",
+                deviceIdentifier, packageArgs.toString(),
+                seedValue, throttleMs, eventCount);
 
         // Determine output filename
         String outputFile;
@@ -94,7 +107,7 @@ public class MonkeyBuilder extends AbstractBuilder {
         // Start monkeying around
         OutputStream monkeyOutput = build.getWorkspace().child(outputFile).write();
         try {
-            log(logger, Messages.STARTING_MONKEY(expandedPackageId, eventCount, seedValue));
+            log(logger, Messages.STARTING_MONKEY(packageNamesLog.toString(), eventCount, seedValue));
             Utils.runAndroidTool(launcher, build.getEnvironment(TaskListener.NULL), monkeyOutput,
                     logger, androidSdk, Tool.ADB, args, null);
         } finally {

--- a/src/main/resources/hudson/plugins/android_emulator/monkey/MonkeyBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/monkey/MonkeyBuilder/config.jelly
@@ -2,7 +2,7 @@
 
     <f:entry title="${%Package ID}">
         <f:textbox name="android-emulator.packageId" value="${instance.packageId}" />
-        <f:description>${%ID of the Android package to monkey around with}</f:description>
+        <f:description>${%ID(s) of the Android package(s) to monkey around with. More packages can be separated by a space}</f:description>
     </f:entry>
 
     <f:entry title="${%Event count}">


### PR DESCRIPTION
The monkey tool allows zero or more packages to be specified using zero
or more -p flags. Package IDs separated by space are treated as
different packages, and will be parsed as individual -p arguments.

This also makes it possible to run the monkey tool without specifying
any package (leaving the field empty).