### PR TITLE
Adds option to run monkey on multiple packages and categories.

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyBuilder.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Random;
 
 import net.sf.json.JSONObject;
@@ -78,10 +79,22 @@ public class MonkeyBuilder extends AbstractBuilder {
 
         // Set up arguments to adb
         final String deviceIdentifier = getDeviceIdentifier(build, listener);
-        final String expandedPackageId = Utils.expandVariables(build, listener, this.packageId);
+        log(logger, String.format("PACKAGE ID: %s", this.packageId));
+        StringBuilder packageArgs = new StringBuilder();
+        StringBuilder packageNamesLog = new StringBuilder(); // For logging
+        if(!this.packageId.equals("")) {
+        	for(String s : this.packageId.split(" ")) {
+        		// Add "-p [packagename]"
+        		packageArgs.append(" -p ");
+        		String expandedPackageId = Utils.expandVariables(build, listener, s);
+        		packageArgs.append(expandedPackageId);
+        		packageNamesLog.append(expandedPackageId);
+        	}
+        }
         final long seedValue = parseSeed(seed);
-        String args = String.format("%s shell monkey -v -v -p %s -s %d --throttle %d %d",
-                deviceIdentifier, expandedPackageId, seedValue, throttleMs, eventCount);
+        String args = String.format("%s shell monkey -v -v %s -s %d --throttle %d %d",
+                deviceIdentifier, packageArgs.toString(),
+                seedValue, throttleMs, eventCount);
 
         // Determine output filename
         String outputFile;
@@ -94,7 +107,7 @@ public class MonkeyBuilder extends AbstractBuilder {
         // Start monkeying around
         OutputStream monkeyOutput = build.getWorkspace().child(outputFile).write();
         try {
-            log(logger, Messages.STARTING_MONKEY(expandedPackageId, eventCount, seedValue));
+            log(logger, Messages.STARTING_MONKEY(packageNamesLog.toString(), eventCount, seedValue));
             Utils.runAndroidTool(launcher, build.getEnvironment(TaskListener.NULL), monkeyOutput,
                     logger, androidSdk, Tool.ADB, args, null);
         } finally {

--- a/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyBuilder.java
@@ -79,7 +79,6 @@ public class MonkeyBuilder extends AbstractBuilder {
 
         // Set up arguments to adb
         final String deviceIdentifier = getDeviceIdentifier(build, listener);
-        log(logger, String.format("PACKAGE ID: %s", this.packageId));
         StringBuilder packageArgs = new StringBuilder();
         StringBuilder packageNamesLog = new StringBuilder(); // For logging
         if(!this.packageId.equals("")) {

--- a/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyBuilder.java
@@ -56,14 +56,20 @@ public class MonkeyBuilder extends AbstractBuilder {
     /** Seed value for the random number generator. Number, "random", or "timestamp". */
     @Exported
     public final String seed;
+    
+    /** Categories to restrict the monkey to. */
+    @Exported
+    public final String categories;
+
 
     @DataBoundConstructor
-    public MonkeyBuilder(String filename, String packageId, Integer eventCount, Integer throttleMs, String seed) {
+    public MonkeyBuilder(String filename, String packageId, Integer eventCount, Integer throttleMs, String seed, String categories) {
         this.filename = Util.fixEmptyAndTrim(filename);
         this.packageId = packageId;
         this.eventCount = eventCount == null ? DEFAULT_EVENT_COUNT : Math.abs(eventCount);
         this.throttleMs = throttleMs == null ? 0 : Math.abs(throttleMs);
         this.seed = seed == null ? "" : seed.trim().toLowerCase();
+        this.categories = categories == null ? "" : categories.trim();
     }
 
     @Override
@@ -90,9 +96,19 @@ public class MonkeyBuilder extends AbstractBuilder {
         		packageNamesLog.append(expandedPackageId);
         	}
         }
+        StringBuilder categoriesArgs = new StringBuilder();
+        if(!this.categories.equals("")) {
+        	for(String s : this.categories.split(" ")) {
+        		// Add "-c [category]"
+        		categoriesArgs.append(" -c ");
+        		String expandedCategory = Utils.expandVariables(build, listener, s);
+        		categoriesArgs.append(expandedCategory);
+        	}
+        }
         final long seedValue = parseSeed(seed);
-        String args = String.format("%s shell monkey -v -v %s -s %d --throttle %d %d",
-                deviceIdentifier, packageArgs.toString(),
+        String args = String.format("%s shell monkey -v -v %s %s -s %d --throttle %d %d",
+                deviceIdentifier, packageArgs.toString(), 
+                categoriesArgs.toString(),
                 seedValue, throttleMs, eventCount);
 
         // Determine output filename

--- a/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyBuilder.java
@@ -56,7 +56,7 @@ public class MonkeyBuilder extends AbstractBuilder {
     /** Seed value for the random number generator. Number, "random", or "timestamp". */
     @Exported
     public final String seed;
-    
+
     /** Categories to restrict the monkey to. */
     @Exported
     public final String categories;
@@ -88,7 +88,7 @@ public class MonkeyBuilder extends AbstractBuilder {
         StringBuilder packageArgs = new StringBuilder();
         StringBuilder packageNamesLog = new StringBuilder(); // For logging
         if(!this.packageId.equals("")) {
-        	for(String s : this.packageId.split(" ")) {
+        	for(String s : this.packageId.split(",")) {
         		// Add "-p [packagename]"
         		packageArgs.append(" -p ");
         		String expandedPackageId = Utils.expandVariables(build, listener, s);
@@ -98,7 +98,7 @@ public class MonkeyBuilder extends AbstractBuilder {
         }
         StringBuilder categoriesArgs = new StringBuilder();
         if(!this.categories.equals("")) {
-        	for(String s : this.categories.split(" ")) {
+        	for(String s : this.categories.split(",")) {
         		// Add "-c [category]"
         		categoriesArgs.append(" -c ");
         		String expandedCategory = Utils.expandVariables(build, listener, s);
@@ -107,7 +107,7 @@ public class MonkeyBuilder extends AbstractBuilder {
         }
         final long seedValue = parseSeed(seed);
         String args = String.format("%s shell monkey -v -v %s %s -s %d --throttle %d %d",
-                deviceIdentifier, packageArgs.toString(), 
+                deviceIdentifier, packageArgs.toString(),
                 categoriesArgs.toString(),
                 seedValue, throttleMs, eventCount);
 

--- a/src/main/resources/hudson/plugins/android_emulator/monkey/MonkeyBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/monkey/MonkeyBuilder/config.jelly
@@ -2,7 +2,7 @@
 
     <f:entry title="${%Package ID}">
         <f:textbox name="android-emulator.packageId" value="${instance.packageId}" />
-        <f:description>${%IDs of the Android packages to monkey around with. More packages can be separated by a space}</f:description>
+        <f:description>${%IDs of the Android packages to monkey around with. More packages can be separated by a comma}</f:description>
     </f:entry>
 
     <f:entry title="${%Event count}">
@@ -25,10 +25,10 @@
             <f:textbox name="android-emulator.seed" value="${instance.seed}" default="0" style="width:12em" />
             <f:description>${%Seed value for the pseudo-random number generator. Enter a number, 'random' or 'timestamp'}</f:description>
         </f:entry>
-        
+
         <f:entry title="${%Categories}">
             <f:textbox name="android-emulator.categories" value="${instance.categories}" />
-            <f:description>${%Allowed categories for the monkey to visit, or unspecified which allows activities in 'Intent.CATEGORY_LAUNCHER' or 'Intent.CATEGORY_MONKEY'. Multiple categories can be separated by a space.}</f:description>
+            <f:description>${%Allowed categories for the monkey to visit, or unspecified which allows activities in 'Intent.CATEGORY_LAUNCHER' or 'Intent.CATEGORY_MONKEY'. Multiple categories can be separated by a comma.}</f:description>
         </f:entry>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/android_emulator/monkey/MonkeyBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/monkey/MonkeyBuilder/config.jelly
@@ -2,7 +2,7 @@
 
     <f:entry title="${%Package ID}">
         <f:textbox name="android-emulator.packageId" value="${instance.packageId}" />
-        <f:description>${%ID(s) of the Android package(s) to monkey around with. More packages can be separated by a space}</f:description>
+        <f:description>${%IDs of the Android packages to monkey around with. More packages can be separated by a space}</f:description>
     </f:entry>
 
     <f:entry title="${%Event count}">

--- a/src/main/resources/hudson/plugins/android_emulator/monkey/MonkeyBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/monkey/MonkeyBuilder/config.jelly
@@ -2,7 +2,7 @@
 
     <f:entry title="${%Package ID}">
         <f:textbox name="android-emulator.packageId" value="${instance.packageId}" />
-        <f:description>${%ID of the Android package to monkey around with}</f:description>
+        <f:description>${%ID(s) of the Android package(s) to monkey around with. More packages can be separated by a space}</f:description>
     </f:entry>
 
     <f:entry title="${%Event count}">

--- a/src/main/resources/hudson/plugins/android_emulator/monkey/MonkeyBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/monkey/MonkeyBuilder/config.jelly
@@ -25,5 +25,10 @@
             <f:textbox name="android-emulator.seed" value="${instance.seed}" default="0" style="width:12em" />
             <f:description>${%Seed value for the pseudo-random number generator. Enter a number, 'random' or 'timestamp'}</f:description>
         </f:entry>
+        
+        <f:entry title="${%Categories}">
+            <f:textbox name="android-emulator.categories" value="${instance.categories}" />
+            <f:description>${%Allowed categories for the monkey to visit, or unspecified which allows activities in 'Intent.CATEGORY_LAUNCHER' or 'Intent.CATEGORY_MONKEY'. Multiple categories can be separated by a space.}</f:description>
+        </f:entry>
     </f:advanced>
 </j:jelly>


### PR DESCRIPTION
The monkey tool allows zero or more packages to be specified using zero
or more -p flags. Package IDs separated by space are treated as
different packages, and will be parsed as individual -p arguments.

This also makes it possible to run the monkey tool without specifying
any package.

The pull request also adds an option to specify one or more categories.