### PR TITLE
Jenkins 28378 pullrequest

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -97,7 +97,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
             String screenResolution, String deviceLocale, String sdCardSize,
             HardwareProperty[] hardwareProperties, boolean wipeData, boolean showWindow,
             boolean useSnapshots, boolean deleteAfterBuild, int startupDelay,
-            String commandLineOptions, String targetAbi, String executable, String avdNameSuffix, boolean checkDevices) {
+            String commandLineOptions, String targetAbi, String executable, String avdNameSuffix, boolean checkForDevices) {
         this.avdName = avdName;
         this.osVersion = osVersion;
         this.screenDensity = screenDensity;
@@ -114,7 +114,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
         this.commandLineOptions = commandLineOptions;
         this.targetAbi = targetAbi;
         this.avdNameSuffix = avdNameSuffix;
-        this.checkForDevices = checkDevices;
+        this.checkForDevices = checkForDevices;
     }
 
     public boolean getUseNamedEmulator() {
@@ -556,9 +556,10 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
     private boolean devicesConnected(AndroidEmulatorContext emu, PrintStream logger) 
     		throws IOException, InterruptedException {
     	final ByteArrayOutputStream deviceList = new ByteArrayOutputStream();
+    	
     	//temporarily change adb server port to standard port when making check
     	int tempPort = emu.adbServerPort();
-    	emu.setAdbServerPort(5097); //Standard port
+    	emu.setAdbServerPort(5037); //Standard port
         emu.getToolProcStarter(Tool.ADB, "devices").stdout(deviceList).stderr(logger).join();
         emu.setAdbServerPort(tempPort);
         String deviceOutput = deviceList.toString();
@@ -901,7 +902,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
                 targetAbi = Util.fixEmptyAndTrim(emulatorData.getString("targetAbi"));
                 avdNameSuffix = Util.fixEmptyAndTrim(emulatorData.getString("avdNameSuffix"));
             }
-            checkForDevices = formData.getBoolean("checkDevices");
+            checkForDevices = formData.getBoolean("checkForDevices");
             wipeData = formData.getBoolean("wipeData");
             showWindow = formData.getBoolean("showWindow");
             useSnapshots = formData.getBoolean("useSnapshots");

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -571,11 +571,6 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
     private boolean devicesConnected(AndroidEmulatorContext emu, PrintStream logger, int adbPort, AbstractBuild<?,?> build) 
     		throws IOException, InterruptedException {
     	final ByteArrayOutputStream deviceList = new ByteArrayOutputStream();
-    	//Check if port is negative, use default if it is.
-    	int port = adbPort;
-    	if (adbPort <= 0) {
-    		port = 5037;
-    	}
     	//Setup a build environment to run the "adb devices" command in.
     	final EnvVars buildEnv = build.getEnvironment(TaskListener.NULL);
     	buildEnv.put("ANDROID_ADB_SERVER_PORT", Integer.toString(adbPort));
@@ -933,6 +928,9 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
             	try {
             		adbServerPort = Integer.parseInt(adbPortData.getString("adbPort"));
             	} catch (NumberFormatException e) { adbServerPort = 5037; }
+            	if (adbServerPort <= 0 || adbServerPort >= 65536) { //Make sure port is in valid range
+            		adbServerPort = 5037;
+            	}
             }
             wipeData = formData.getBoolean("wipeData");
             showWindow = formData.getBoolean("showWindow");

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
@@ -74,6 +74,9 @@ public class AndroidEmulatorContext {
 	public int adbServerPort() {
 		return adbServerPort;
 	}
+	public void setAdbServerPort(int adbServerPort) {
+		this.adbServerPort = adbServerPort;
+	}
 	public String serial() {
 		return serial;
 	}

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
@@ -74,9 +74,6 @@ public class AndroidEmulatorContext {
 	public int adbServerPort() {
 		return adbServerPort;
 	}
-	public void setAdbServerPort(int adbServerPort) {
-		this.adbServerPort = adbServerPort;
-	}
 	public String serial() {
 		return serial;
 	}

--- a/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
@@ -100,6 +100,11 @@
               checked="${instance.useSnapshots}" />
           <label class="attach-previous">${%Use emulator snapshots}</label>
         </f:entry>
+        <f:entry help="/plugin/android-emulator/help-checkDevices.html">
+          <f:checkbox id="android-emulator.checkdevices" name="android-emulator.checkDevices"
+              checked="${instance.checkDevices}" />
+          <label class="attach-previous">${%Only start emulator if no devices are attached}</label>
+        </f:entry>
       </f:section>
 
     </table>

--- a/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
@@ -101,8 +101,8 @@
           <label class="attach-previous">${%Use emulator snapshots}</label>
         </f:entry>
         <f:entry help="/plugin/android-emulator/help-checkDevices.html">
-          <f:checkbox id="android-emulator.checkdevices" name="android-emulator.checkDevices"
-              checked="${instance.checkDevices}" />
+          <f:checkbox id="android-emulator.checkForDevices" name="android-emulator.checkForDevices"
+              checked="${instance.checkForDevices}" />
           <label class="attach-previous">${%Only start emulator if no devices are attached}</label>
         </f:entry>
       </f:section>

--- a/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
@@ -101,9 +101,19 @@
           <label class="attach-previous">${%Use emulator snapshots}</label>
         </f:entry>
         <f:entry help="/plugin/android-emulator/help-checkDevices.html">
-          <f:checkbox id="android-emulator.checkForDevices" name="android-emulator.checkForDevices"
-              checked="${instance.checkForDevices}" />
-          <label class="attach-previous">${%Only start emulator if no devices are attached}</label>
+          
+          	<table>
+  	    	  <f:optionalBlock title="${%Only start emulator if no devices are attached}" name="android-emulator.checkForDevices" 
+  	              id="android-emulator.checkForDevices" checked="${instance.checkForDevices}"
+  	               >
+              	<f:entry title="${%Select ADB server port. Default port: 5037}">
+          		  <f:textbox name="android-emulator.adbPort" id="android-emulator.adbPort" 
+          		      value="${instance.adbPort}" style="width:3em" default="5037"
+          		      checkUrl="'descriptorByName/AndroidEmulator/checkAdbServerPortValue?value='+escape(this.value)" />
+          		</f:entry >
+        	  </f:optionalBlock>
+            </table>
+          
         </f:entry>
       </f:section>
 

--- a/src/main/resources/hudson/plugins/android_emulator/Messages.properties
+++ b/src/main/resources/hudson/plugins/android_emulator/Messages.properties
@@ -91,6 +91,8 @@ EMULATOR_IS_READY=Emulator is ready for use (took {0} seconds)
 STOPPING_EMULATOR=Stopping Android emulator
 EMULATOR_SHUTDOWN_FAILED=Failed to shut down emulator; the process may still be running...
 ARCHIVING_LOG=Archiving emulator log
+DEVICES_CONNECTED=Devices detected, skipping emulator start-up procedure
+NO_DEVICES_CONNECTED=No devices connected, continuing emulator start-up
 
 # Deletion
 AVD_DIRECTORY_NOT_FOUND=Could not find AVD directory ''{0}''

--- a/src/main/resources/hudson/plugins/android_emulator/Messages.properties
+++ b/src/main/resources/hudson/plugins/android_emulator/Messages.properties
@@ -23,6 +23,9 @@ INVALID_TARGET_ABI=Unrecognised target ABI
 INVALID_EXECUTABLE=Unrecognised executable
 SD_CARD_SIZE_TOO_SMALL=SD card size must be at least 9 megabytes
 EMULATOR_CONFIGURATION_BAD=Unrecognised Android emulator configuration: ''{0}''
+AVD_SERVER_PORT_REQUIRED="AVD server port must be specified"
+AVD_SERVER_PORT_NEGATIVE="AVD server port must be a positive number larger than 0"
+AVD_SERVER_PORT_NOT_A_NUMBER="''{0}'' is not a number"
 
 # SDK installation
 INSTALLING_SDK=No Android SDK found; let''s install it automatically...

--- a/src/main/webapp/help-checkDevices.html
+++ b/src/main/webapp/help-checkDevices.html
@@ -1,0 +1,8 @@
+<div>
+	Select this option, if you may have physical devices connected to the server, and only want to start an emulator
+	if they are not connected.
+	<p>
+	When this option is checked, the plugin will run the <pre>adb -d devices</pre> command to see if there are any physical devices
+	connected before starting an emulator. It will only start a new emulator if there are no devices connected. 
+	The adb server port number option, specifies which port the adb server is using.
+</div>


### PR DESCRIPTION
Adds an option to check if the adb server already has connected devices. If connected devices are found the emulator startup procedure is skipped. It is possible to configure which port the adb server is run on, when performing the check. 
