### PR TITLE
Use a valid port range

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.565.1</version>
+    <version>1.565.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
@@ -49,7 +49,7 @@ public class AndroidEmulatorContext {
 		// Use the Port Allocator plugin to reserve the ports we need
 		portAllocator = PortAllocationManager.getManager(computer);
 		final int PORT_RANGE_START = 5554;
-		final int PORT_RANGE_END = 9999; // Make sure the port is four digits, as there are tools that rely on this
+		final int PORT_RANGE_END = 5680; // Make sure the port is four digits, as there are tools that rely on this
 		int[] ports = portAllocator.allocatePortRange(build, PORT_RANGE_START, PORT_RANGE_END, 3, true);
 		userPort = ports[0];
 		adbPort = ports[1];

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
@@ -26,6 +26,8 @@ public class AndroidEmulatorContext {
 
 	private int adbPort, userPort, adbServerPort;
 	private String serial;
+	private String emulatorSerial;
+	private boolean connectedToAdbServerPort;
 
 	private PortAllocationManager portAllocator;
 	private Proc emulatorProcess;
@@ -48,14 +50,28 @@ public class AndroidEmulatorContext {
 
 		// Use the Port Allocator plugin to reserve the ports we need
 		portAllocator = PortAllocationManager.getManager(computer);
+		
+		// This port range is the one "emulator -port" states to accept
 		final int PORT_RANGE_START = 5554;
-		final int PORT_RANGE_END = 5680; // Make sure the port is four digits, as there are tools that rely on this
-		int[] ports = portAllocator.allocatePortRange(build, PORT_RANGE_START, PORT_RANGE_END, 3, true);
-		userPort = ports[0];
-		adbPort = ports[1];
-		adbServerPort = ports[2];
+		final int PORT_RANGE_END = 5585; // Make sure the port is four digits, as there are tools that rely on this
+		
+		// Make sure userPort is even, as required by ADB's documentation
+		// See: http://developer.android.com/tools/help/adb.html
+		int[] ports = null;
+		do {
+			if (ports != null) {
+				for (int p : ports) {
+					portAllocator.free(p);
+				}
+			}
+			ports = portAllocator.allocatePortRange(build, PORT_RANGE_START, PORT_RANGE_END, 3, true);
+			userPort = ports[0];
+			adbPort = ports[1];
+			adbServerPort = ports[2];
+		} while (userPort % 2 == 1);
 
 		serial = String.format("localhost:%d", adbPort);
+		emulatorSerial = String.format("emulator-%d", userPort);
 	}
 
 	public void cleanUp() {
@@ -76,6 +92,18 @@ public class AndroidEmulatorContext {
 	}
 	public String serial() {
 		return serial;
+	}
+	public String emulatorSerial() {
+		return emulatorSerial;
+	}
+	public String effectiveSerial() {
+		return connectedToAdbServerPort ? serial : emulatorSerial;
+	}
+	public boolean connectedToAdbServerPort() {
+		return connectedToAdbServerPort;
+	}
+	public void setConnectedToAdbServerPort(boolean connectedToAdbPort) {
+		connectedToAdbServerPort = connectedToAdbPort;
 	}
 
 	public BuildListener listener() {


### PR DESCRIPTION
 - This fixes the infamous device offline messages

This one was really hard to get... The documentation is messy, and error handling on Android tools is poor.

According to the [`adb` documentation](http://developer.android.com/tools/help/adb.html), valid ports are in the range 5555 to 5585. However, it is known that using `emulator -ports X,Y` will start the emulator regardless of what X and Y are (though it still seems to need a 4 digit number). Connecting to devices by `adb connect localhost:Y` will succeed, yet `adb devices` would sometimes show `emulator-X online` and `localhost:Y offline`.

A nice clue comes from using `emulator -port` instead of `-ports`. Using numbers that would get `-ports` working without a second thought would throw:

 > emulator: ERROR: option -port must be followed by an even integer number between 5554 and 5680

I have scripted a test, running `emulator -ports`  on every pair from 5554 to over 6000 and the evidence shows clearly that at the pair 5680/5681 it just stops working.

Reducing the port range this way has allowed the plugin to work every single time consistently.

The only alterantive to reducing the port ranges this way is:
* stop using `adb connect localhost:YYY`
* start using `adb -s emulator-XXX`. The `emulator-` device seems to work with all ports that `-ports` accepts.