### PR TITLE
Add a checker if a given APK file path is relative.

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/InstallBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/InstallBuilder.java
@@ -19,10 +19,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.io.Serializable;
+import java.io.*;
 import java.util.regex.Pattern;
 
 public class InstallBuilder extends AbstractBuilder {
@@ -74,6 +71,12 @@ public class InstallBuilder extends AbstractBuilder {
         final String apkFile = getApkFile();
         if (Util.fixEmptyAndTrim(apkFile) == null) {
             AndroidEmulator.log(logger, Messages.APK_NOT_SPECIFIED());
+            return false;
+        }
+
+        // Check whether a value is relative path
+        if (Util.fixEmptyAndTrim(apkFile).startsWith(File.separator)) {
+            AndroidEmulator.log(logger, Messages.APK_PATH_MUST_BE_RELATIVE());
             return false;
         }
 

--- a/src/main/java/hudson/plugins/android_emulator/InstallBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/InstallBuilder.java
@@ -19,7 +19,10 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.Serializable;
 import java.util.regex.Pattern;
 
 public class InstallBuilder extends AbstractBuilder {

--- a/src/main/resources/hudson/plugins/android_emulator/Messages.properties
+++ b/src/main/resources/hudson/plugins/android_emulator/Messages.properties
@@ -104,6 +104,7 @@ SENDING_COMMAND_TIMED_OUT=Aborting emulator command ''{0}'' as it''s taking too 
 INSTALL_ANDROID_PACKAGE=Install Android package
 UNINSTALL_ANDROID_PACKAGE=Uninstall Android package
 APK_NOT_SPECIFIED=No APK file was specified to be installed
+APK_PATH_MUST_BE_RELATIVE=APK file path must be relative (e.g., app/build/.../...apk)
 APK_NOT_FOUND=Could not find APK file ''{0}'' to be installed
 COULD_NOT_DETERMINE_APK_PACKAGE=Could not determine package name from APK file ''{0}''; cannot uninstall
 WAITING_FOR_CORE_PROCESS=Waiting for system package manager to start...


### PR DESCRIPTION
I found when I set the APK install, the path configuration is confusing. Since we are going to call Utils.expandVariables which combines the given path and workspace, and often users do not now/should not know the absolute path, I think checking if a given APK file path is relative is necessary and useful for users. 