### PR TITLE
Added monkey result status for "No activities found to run, monkey aborted."

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyAction.java
+++ b/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyAction.java
@@ -46,6 +46,9 @@ public class MonkeyAction implements Action {
         case UnrecognisedFormat:
             description = Messages.MONKEY_RESULT_UNRECOGNISED();
             break;
+        case NoActivityFound:
+            description = Messages.MONKEY_RESULT_NOACTIVITYFOUND();
+            break;
         case NothingToParse:
         default:
             description = Messages.MONKEY_RESULT_NONE();

--- a/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyRecorder.java
+++ b/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyRecorder.java
@@ -116,6 +116,9 @@ public class MonkeyRecorder extends Recorder {
                 } else if ("NOT RESPONDING".equals(reason)) {
                     result = MonkeyResult.AppNotResponding;
                 }
+              // Case for "** No activities found to run, monkey aborted."
+            } else if (monkeyOutput.contains("No activities found to run")) {
+                result = MonkeyResult.NoActivityFound;
             }
 
             // Set configured build result

--- a/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyResult.java
+++ b/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyResult.java
@@ -10,5 +10,7 @@ enum MonkeyResult {
     /** No monkey output was found to parse */
     NothingToParse,
     /** Monkey output was given, but outcome couldn't be determined */
-    UnrecognisedFormat
+    UnrecognisedFormat,
+    /** ** No activities found to run, monkey aborted. Package name is wrong or package not installed */
+    NoActivityFound
 }

--- a/src/main/resources/hudson/plugins/android_emulator/Messages.properties
+++ b/src/main/resources/hudson/plugins/android_emulator/Messages.properties
@@ -150,6 +150,7 @@ MONKEY_RESULT_SUCCESS=Succeeded after {0} events
 MONKEY_RESULT_CRASH=Crashed after {0} of {1} events
 MONKEY_RESULT_ANR=Stopped responding after {0} of {1} events
 MONKEY_RESULT_UNRECOGNISED=Could not determine results from file
+MONKEY_RESULT_NOACTIVITYFOUND=No activities found to run (Package not installed or Wrong Package Id)
 MONKEY_RESULT_NONE=No monkey output was provided
 BUILD_RESULT_UNSTABLE=Unstable
 BUILD_RESULT_FAILURE=Failure


### PR DESCRIPTION
When users do not install pkg or put the wrong package id, the monkey is not running, but currently we say, "Could not determine results from file."

![screenshot 2015-07-19 15 27 53](https://cloud.githubusercontent.com/assets/901975/8764991/c857bf7c-2e2a-11e5-946f-c16842e52298.png)

This patch gives more detailed information for users.

