### PR TITLE
Android emulator startup and config

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -349,7 +349,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
 
         final long bootTime = System.currentTimeMillis();
 
-        if (!emuConfig.isNamedEmulator() && !emuConfig.isRunningDevice()) {
+        if (!emuConfig.isRunningDevice()) {
             // Compile complete command for starting emulator
             final String emulatorArgs = emuConfig.getCommandArguments(snapshotState,
                     androidSdk.supportsSnapshots(), emu.userPort(), emu.adbPort(), emu.getEmulatorCallbackPort(), ADB_CONNECT_TIMEOUT_MS / 1000);

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -375,7 +375,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
         // indicate that any methods wanting to check the "emulator" process state should ignore it.
         boolean ignoreProcess = !launcher.isUnix() && androidSdk.getSdkToolsMajorVersion() >= 12;
 
-        Thread.sleep(5000);
+        // Thread.sleep(5000);
 
         // Notify adb of our existence (though the emulator should do this anyway)
         int result = emu.getToolProcStarter(Tool.ADB, "connect " + emu.connectString()).stdout(logger).stderr(logger).join();
@@ -536,7 +536,8 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
 
     private static void disconnectEmulator(AndroidEmulatorContext emu)
             throws IOException, InterruptedException {
-        final String args = "disconnect "+ emu.connectString();
+        // The docs say host:port is valid, but reality is different.
+        final String args = "disconnect"; //+ emu.connectString();
         ArgumentListBuilder adbDisconnectCmd = emu.getToolCommand(Tool.ADB, args);
         emu.getProcStarter(adbDisconnectCmd).start().joinWithTimeout(5L, TimeUnit.SECONDS, emu.launcher().getListener());
     }
@@ -740,6 +741,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
                 if (retVal == 0) {
                     // If boot is complete, our work here is done
                     String result = stream.toString().trim();
+                    log(emu.logger(), result);
                     if (result.equals(expectedAnswer)) {
                         return true;
                     }

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -375,8 +375,10 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
         // indicate that any methods wanting to check the "emulator" process state should ignore it.
         boolean ignoreProcess = !launcher.isUnix() && androidSdk.getSdkToolsMajorVersion() >= 12;
 
+        Thread.sleep(5000);
+
         // Notify adb of our existence (though the emulator should do this anyway)
-        int result = emu.getToolProcStarter(Tool.ADB, "connect " + emu.serial()).stdout(logger).stderr(logger).join();
+        int result = emu.getToolProcStarter(Tool.ADB, "connect " + emu.connectString()).stdout(logger).stderr(logger).join();
         if (result != 0) { // adb currently only ever returns 0!
             log(logger, Messages.CANNOT_CONNECT_TO_EMULATOR());
             build.setResult(Result.NOT_BUILT);
@@ -528,13 +530,13 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
 
     private static void connectEmulator(AndroidEmulatorContext emu)
             throws IOException, InterruptedException {
-        ArgumentListBuilder adbConnectCmd = emu.getToolCommand(Tool.ADB, "connect " + emu.serial());
+        ArgumentListBuilder adbConnectCmd = emu.getToolCommand(Tool.ADB, "connect " + emu.connectString());
         emu.getProcStarter(adbConnectCmd).start().joinWithTimeout(5L, TimeUnit.SECONDS, emu.launcher().getListener());
     }
 
     private static void disconnectEmulator(AndroidEmulatorContext emu)
             throws IOException, InterruptedException {
-        final String args = "disconnect "+ emu.serial();
+        final String args = "disconnect "+ emu.connectString();
         ArgumentListBuilder adbDisconnectCmd = emu.getToolCommand(Tool.ADB, args);
         emu.getProcStarter(adbDisconnectCmd).start().joinWithTimeout(5L, TimeUnit.SECONDS, emu.launcher().getListener());
     }

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
@@ -48,14 +48,18 @@ public class AndroidEmulatorContext {
 
 		// Use the Port Allocator plugin to reserve the ports we need
 		portAllocator = PortAllocationManager.getManager(computer);
+        // According to https://developer.android.com/tools/help/adb.html,
+        // It locates emulator/device instances by scanning odd-numbered ports in the range 5555 to 5585,
+        // the range used by emulators/devices. Ports are allocated in pairs console/adb
 		final int PORT_RANGE_START = 5554;
-		final int PORT_RANGE_END = 9999; // Make sure the port is four digits, as there are tools that rely on this
-		int[] ports = portAllocator.allocatePortRange(build, PORT_RANGE_START, PORT_RANGE_END, 3, true);
+		final int PORT_RANGE_END = 5585; // Make sure the port is four digits, as there are tools that rely on this
+        // Allocate 4 ports so that we start on an even every time
+		int[] ports = portAllocator.allocatePortRange(build, PORT_RANGE_START, PORT_RANGE_END, 4, true);
 		userPort = ports[0];
 		adbPort = ports[1];
 		adbServerPort = ports[2];
-
-		serial = String.format("localhost:%d", adbPort);
+        // This is a best guess. adb get-serialno will return the actual value
+		serial = String.format("emulator-%d", userPort);
 	}
 
 	public void cleanUp() {
@@ -74,6 +78,11 @@ public class AndroidEmulatorContext {
 	public int adbServerPort() {
 		return adbServerPort;
 	}
+
+    public String connectString() {
+        return "localhost:" + userPort;
+    }
+
 	public String serial() {
 		return serial;
 	}

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
@@ -54,10 +54,10 @@ public class AndroidEmulatorContext {
 		final int PORT_RANGE_START = 5554;
 		final int PORT_RANGE_END = 5585; // Make sure the port is four digits, as there are tools that rely on this
         // Allocate 4 ports so that we start on an even every time
-		int[] ports = portAllocator.allocatePortRange(build, PORT_RANGE_START, PORT_RANGE_END, 4, true);
+		int[] ports = portAllocator.allocatePortRange(build, PORT_RANGE_START, PORT_RANGE_END, 2, true);
 		userPort = ports[0];
 		adbPort = ports[1];
-		adbServerPort = ports[2];
+		adbServerPort = 5037; // This is the standard according to the android docs
         // This is a best guess. adb get-serialno will return the actual value
 		serial = String.format("emulator-%d", userPort);
 	}

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
@@ -93,6 +93,10 @@ public class AndroidEmulatorContext {
 		return serial;
 	}
 
+    public void setSerial(String serial)  {
+        this.serial = serial;
+    }
+
 	public BuildListener listener() {
 		return listener;
 	}

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
@@ -24,7 +24,7 @@ public class AndroidEmulatorContext {
     /** Interval during which an emulator command should complete. */
     public static final int EMULATOR_COMMAND_TIMEOUT_MS = 60 * 1000;
 
-	private int adbPort, userPort, adbServerPort;
+	private int adbPort, userPort, adbServerPort, emulatorCallbackPort;
 	private String serial;
 
 	private PortAllocationManager portAllocator;
@@ -58,6 +58,7 @@ public class AndroidEmulatorContext {
 		userPort = ports[0];
 		adbPort = ports[1];
 		adbServerPort = 5037; // This is the standard according to the android docs
+        emulatorCallbackPort = portAllocator.allocateRandom(build, 49152);
         // This is a best guess. adb get-serialno will return the actual value
 		serial = String.format("emulator-%d", userPort);
 	}
@@ -78,6 +79,7 @@ public class AndroidEmulatorContext {
 	public int adbServerPort() {
 		return adbServerPort;
 	}
+    public int getEmulatorCallbackPort() { return emulatorCallbackPort; }
 
     public String connectString() {
         return "localhost:" + userPort;

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorContext.java
@@ -52,12 +52,16 @@ public class AndroidEmulatorContext {
         // It locates emulator/device instances by scanning odd-numbered ports in the range 5555 to 5585,
         // the range used by emulators/devices. Ports are allocated in pairs console/adb
 		final int PORT_RANGE_START = 5554;
-		final int PORT_RANGE_END = 5585; // Make sure the port is four digits, as there are tools that rely on this
-        // Allocate 4 ports so that we start on an even every time
+		final int PORT_RANGE_END = 5554 + (2 * 64); // Make sure the port is four digits, as there are tools that rely on this
+        // Allocate 2 ports so that we start on an even every time.
 		int[] ports = portAllocator.allocatePortRange(build, PORT_RANGE_START, PORT_RANGE_END, 2, true);
 		userPort = ports[0];
 		adbPort = ports[1];
-		adbServerPort = 5037; // This is the standard according to the android docs
+        // Allocate server port starting with the preferred default
+        final int SERVER_PORT_RANGE_START = 5037; // This is the standard according to the android docs
+        final int SERVER_PORT_RANGE_END = 5553;
+        ports = portAllocator.allocatePortRange(build, SERVER_PORT_RANGE_START, SERVER_PORT_RANGE_END, 1, true);
+		adbServerPort = ports[0];
         emulatorCallbackPort = portAllocator.allocateRandom(build, 49152);
         // This is a best guess. adb get-serialno will return the actual value
 		serial = String.format("emulator-%d", userPort);

--- a/src/main/java/hudson/plugins/android_emulator/Constants.java
+++ b/src/main/java/hudson/plugins/android_emulator/Constants.java
@@ -39,7 +39,7 @@ public interface Constants {
 
     // From hudson.Util.VARIABLE
     static final String REGEX_VARIABLE = "\\$([A-Za-z0-9_]+|\\{[A-Za-z0-9_]+\\}|\\$)";
-    static final String REGEX_AVD_NAME = "[a-zA-Z0-9._-]+";
+    static final String REGEX_AVD_NAME = "[a-zA-Z0-9._-]+(:[0-9]+)?";
     static final String REGEX_LOCALE = "[a-z]{2}_[A-Z]{2}";
     static final String REGEX_SCREEN_DENSITY = "[0-9]{2,4}|(?i)(x?x?h|[lm])dpi";
     static final String REGEX_SCREEN_RESOLUTION = "[0-9]{3,4}x[0-9]{3,4}";

--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -303,11 +303,11 @@ class EmulatorConfig implements Serializable {
      * @return A string of command line arguments.
      */
     public String getCommandArguments(SnapshotState snapshotState, boolean sdkSupportsSnapshots,
-            int userPort, int adbPort) {
+            int userPort, int adbPort, int callbackPort, int consoleTimeout) {
         StringBuilder sb = new StringBuilder();
 
         // Set basics
-        sb.append(String.format(" -ports %s,%s", userPort, adbPort));
+        sb.append(String.format(" -ports %s,%s -report-console tcp:%s,max=%s", userPort, adbPort, callbackPort, consoleTimeout));
         if (!isNamedEmulator()) {
             sb.append(" -prop persist.sys.language=");
             sb.append(getDeviceLanguage());

--- a/src/main/java/hudson/plugins/android_emulator/TaskDispatcher.java
+++ b/src/main/java/hudson/plugins/android_emulator/TaskDispatcher.java
@@ -35,10 +35,12 @@ public class TaskDispatcher extends QueueTaskDispatcher {
 
     @Override
     public CauseOfBlockage canTake(Node node, Task task) {
+
         // If the given task doesn't use the AndroidEmulator BuildWrapper, we don't care.
         // Or, if there is an emulator hash, but with unresolved environment variables, we shouldn't block the build
         String desiredHash = getEmulatorConfigHashForTask(node, task);
-        if (desiredHash == null || desiredHash.contains("$")) {
+
+        if (desiredHash == null || desiredHash.contains("$") || true) {
             return null;
         }
 

--- a/src/main/java/hudson/plugins/android_emulator/TaskDispatcher.java
+++ b/src/main/java/hudson/plugins/android_emulator/TaskDispatcher.java
@@ -21,7 +21,7 @@ import hudson.plugins.android_emulator.AndroidEmulator.DescriptorImpl;
  * once concurrently on any one build machine.
  * <p>
  * From the given {@link hudson.model.Queue.Task Task}, we form a hash of the emulator configuration
- * and check whether any other build currently running on the given {@link hudeon.model.Node Node}
+ * and check whether any other build currently running on the given {@link hudson.model.Node Node}
  * is already using this configuration. If so, we veto execution of the given {@code Task}.
  * </p>
  * As Android emulator attributes will quite often be parameterised (especially for matrix builds),

--- a/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
@@ -118,6 +118,10 @@
               default="0" />
           <f:description>${%Wait this many seconds before attempting to start the emulator}</f:description>
         </f:entry>
+        <f:entry title="${%Startup timeout}" help="/plugin/android-emulator/help-startupTimeout.html">
+          <f:textbox name="android-emulator.startupTimeout" value="${instance.startupTimeout}" style="width:4em"/>
+          <f:description>${%Wait this many seconds before aborting the startup of the emulator}</f:description>
+        </f:entry>
         <f:entry title="${%Emulator options}" help="/plugin/android-emulator/help-commandLineOptions.html">
           <f:textbox name="android-emulator.commandLineOptions" value="${instance.commandLineOptions}" />
           <f:description>${%Will be given when starting the Android &lt;tt>emulator&lt;/tt> executable}</f:description>

--- a/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
@@ -3,7 +3,7 @@
   <f:block>
     <table style="margin-left:2em">
 
-      <f:radioBlock name="android-emulator.useNamed" value="true"
+      <f:radioBlock name="android-emulator.useNamed" value="named"
           title="${%Run existing emulator}" checked="${instance.useNamedEmulator}"
           help="/plugin/android-emulator/help-emulatorNamed.html">
         <f:block>
@@ -17,8 +17,26 @@
         </f:block>
       </f:radioBlock>
 
-      <f:radioBlock name="android-emulator.useNamed" value="false"
-          title="${%Run emulator with properties}" checked="${!instance.useNamedEmulator}"
+      <f:radioBlock name="android-emulator.useNamed" value="running"
+          title="${%Connect to existing device}" checked="${instance.useRunningDevice}"
+          help="/plugin/android-emulator/help-runningDevice.html">
+        <f:block>
+          <table style="margin-left:2em">
+            <f:entry title="${%Device name}" help="/plugin/android-emulator/help-avdName.html">
+              <f:textbox name="android-emulator.avdName" value="${instance.avdName}"
+                  checkUrl="'descriptorByName/AndroidEmulator/checkAvdName?value='+escape(this.value)"/>
+              <f:description>${%Enter the name of an existing Android device}</f:description>
+            </f:entry>
+            <f:entry title="${%Android OS version}" help="/plugin/android-emulator/help-osVersion.html">
+              <f:editableComboBox id="android-emulator.osVersion" field="osVersion"
+                  items="${descriptor.androidVersions}"/>
+            </f:entry>
+          </table>
+        </f:block>
+      </f:radioBlock>
+
+      <f:radioBlock name="android-emulator.useNamed" value="create"
+          title="${%Run emulator with properties}" checked="${instance.createEmulator}"
           help="/plugin/android-emulator/help-emulatorCustom.html">
         <f:block>
           <table style="margin-left:2em">

--- a/src/main/resources/hudson/plugins/android_emulator/Messages.properties
+++ b/src/main/resources/hudson/plugins/android_emulator/Messages.properties
@@ -61,6 +61,8 @@ PLATFORM_IMAGE_NOT_FOUND=Cannot find desired platform image at ''{0}''
 
 # Execution
 WAITING_FOR_EMULATOR=Waiting for the configured Android emulator to become available
+EMULATOR_CONSOLE_REPORT=Emulator reported that the console is available on port {0}
+EMULATOR_STATE_REPORT=Emulator reports its state as ''{0}''
 ERROR_MISCONFIGURED=Cannot start Android emulator due to misconfiguration: {0}
 SDK_TOOLS_NOT_FOUND=Required Android tools not found in PATH; cannot continue
 USING_PATH=[none found; relying on PATH]

--- a/src/main/webapp/help-avdName.html
+++ b/src/main/webapp/help-avdName.html
@@ -1,8 +1,9 @@
 <div>
   The names of existing Android emulator configurations (AVDs) can be seen by running the 
-  following command from the Android SDK: <tt>android list avd</tt>.
+  following command from the Android SDK: <tt>android list avd</tt>. Remote running devices
+    can also be accessed in this manner and are typically named as <tt>host:port</tt>
 <p>
-  The AVD must already exist at build time on the machine the build will be executed on &mdash;
+  For named emulators the AVD must already exist at build time on the machine the build will be executed on &mdash;
   the emulator configuration will not be automatically created or copied from another machine.
 </p>
   You can also do environment variable substitution for this setting, in the format:

--- a/src/main/webapp/help-runningDevice.html
+++ b/src/main/webapp/help-runningDevice.html
@@ -1,0 +1,1 @@
+Connects to a running device over tcpip &mdash; typically a hardware device or an Android VM.

--- a/src/main/webapp/help-startupTimeout.html
+++ b/src/main/webapp/help-startupTimeout.html
@@ -1,0 +1,5 @@
+This determines how long the Android Emulator plugin should wait for the emulator to start at the beginning of a build.
+<p>
+    This is useful, for example, if starting the emulator takes some considerable time - for instance if you are unable to use hardware acceleration.
+    By default the plugin waits for 360 seconds. This value is doubled to 720 seconds for first time boots without an initial snapshot.<br/>
+</p>

--- a/src/test/java/hudson/plugins/android_emulator/EmulatorConfigTest.java
+++ b/src/test/java/hudson/plugins/android_emulator/EmulatorConfigTest.java
@@ -11,15 +11,15 @@ public class EmulatorConfigTest {
     public void shouldSelectExecutor64WhenPassedAsExecutorAndAvdIsSelected() {
         EmulatorConfig emulatorConfigWithAvdName =
                 EmulatorConfig.create("hudson_en-US_160_WVGA_android-21", "5.0", "160", "WVGA", "", "", false, false,
-                        false, "", "", "", "emulator64-arm", "");
+                        false, false, "", "", "", "emulator64-arm", "");
         assertEquals(Tool.EMULATOR64_ARM, emulatorConfigWithAvdName.getExecutable());
     }
 
     @Test
     public void shouldSelectExecutor64WhenPassedAsExecutorAndAvdIsEmpty() {
         EmulatorConfig emulatorConfigWithNoAvdName =
-                EmulatorConfig.create("", "5.0", "160", "WVGA", "", "", false, false, false, "", "", "",
-                        "emulator64-arm", "");
+                EmulatorConfig.create("", "5.0", "160", "WVGA", "", "", false, false, false, false, "", "",
+                        "", "emulator64-arm", "");
         assertEquals(Tool.EMULATOR64_ARM, emulatorConfigWithNoAvdName.getExecutable());
     }
 


### PR DESCRIPTION
The current version of the plugin is broken when using the current version of the android tools. I have spent a long, long time experimenting with different options and trying to work around problems. This pull request is the culmination of that effort. It does the following:
- Fixes the adb port range as per android docmentation
- Uses emulator port reporting rather than sitting on the emulator port to diagnose initial startup
- Uses the correct arguments for connect and -s
- Makes the emulator startup timeout configurable.
With these changes I now have a fairly stable environment.