### PR TITLE
Implement build step to install Android project prerequisites.

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -549,7 +549,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
     }
 
     /** Helper method for writing to the build log in a consistent manner. */
-    synchronized static void log(final PrintStream logger, final String message, final Throwable t) {
+    public synchronized static void log(final PrintStream logger, final String message, final Throwable t) {
         log(logger, message, false);
         StringWriter s = new StringWriter();
         t.printStackTrace(new PrintWriter(s));

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorException.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulatorException.java
@@ -37,17 +37,3 @@ final class EmulatorCreationException extends AndroidEmulatorException {
     private static final long serialVersionUID = 1L;
 
 }
-
-final class SdkInstallationException extends AndroidEmulatorException {
-
-    SdkInstallationException(String message) {
-        super(message);
-    }
-
-    SdkInstallationException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    private static final long serialVersionUID = 1L;
-
-}

--- a/src/main/java/hudson/plugins/android_emulator/SdkInstallationException.java
+++ b/src/main/java/hudson/plugins/android_emulator/SdkInstallationException.java
@@ -1,0 +1,15 @@
+package hudson.plugins.android_emulator;
+
+public final class SdkInstallationException extends AndroidEmulatorException {
+
+    SdkInstallationException(String message) {
+        super(message);
+    }
+
+    SdkInstallationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/src/main/java/hudson/plugins/android_emulator/SdkInstaller.java
+++ b/src/main/java/hudson/plugins/android_emulator/SdkInstaller.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Semaphore;
 
 import org.apache.commons.lang.StringUtils;
 
-class SdkInstaller {
+public class SdkInstaller {
 
     /** Recent version of the Android SDK that will be installed. */
     private static final int SDK_VERSION = 16;
@@ -153,17 +153,32 @@ class SdkInstaller {
     }
 
     /**
-     * Installs the given platform and its dependencies into the given installation, if necessary.
+     * Installs the platform for an emulator config into the given SDK installation, if necessary.
      *
      * @param logger Logs things.
      * @param launcher Used to launch tasks on the remote node.
-     * @param sdkRoot Root of the SDK installation to install components for.
+     * @param sdk SDK installation to install components for.
+     * @param emuConfig Specifies the platform to be installed.
      */
     static void installDependencies(PrintStream logger, Launcher launcher,
             AndroidSdk sdk, EmulatorConfig emuConfig) throws IOException, InterruptedException {
         // Get AVD platform from emulator config
         String platform = getPlatformForEmulator(launcher, emuConfig);
 
+        // Install platform and any dependencies it may have
+        installPlatform(logger, launcher, sdk, platform);
+    }
+
+    /**
+     * Installs the given platform and its dependencies into the given installation, if necessary.
+     *
+     * @param logger Logs things.
+     * @param launcher Used to launch tasks on the remote node.
+     * @param sdk SDK installation to install components for.
+     * @param platform Specifies the platform to be installed.
+     */
+    static void installPlatform(PrintStream logger, Launcher launcher,
+            AndroidSdk sdk, String platform) throws IOException, InterruptedException {
         // Check whether this platform is already installed
         ByteArrayOutputStream targetList = new ByteArrayOutputStream();
         // Preferably we'd use the "--compact" flag here, but it wasn't added until r12

--- a/src/main/java/hudson/plugins/android_emulator/builder/ProjectPrerequisitesInstaller.java
+++ b/src/main/java/hudson/plugins/android_emulator/builder/ProjectPrerequisitesInstaller.java
@@ -1,0 +1,143 @@
+package hudson.plugins.android_emulator.builder;
+
+import static hudson.plugins.android_emulator.AndroidEmulator.log;
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.FilePath.FileCallable;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Descriptor;
+import hudson.plugins.android_emulator.Messages;
+import hudson.plugins.android_emulator.SdkInstaller;
+import hudson.plugins.android_emulator.sdk.AndroidSdk;
+import hudson.plugins.android_emulator.util.Utils;
+import hudson.remoting.VirtualChannel;
+import hudson.tasks.Builder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashSet;
+
+import org.apache.tools.ant.DirectoryScanner;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class ProjectPrerequisitesInstaller extends AbstractBuilder {
+
+    @DataBoundConstructor
+    public ProjectPrerequisitesInstaller() {
+        // Nowt to do
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+            throws InterruptedException, IOException {
+        final PrintStream logger = listener.getLogger();
+
+        // Gather list of platforms specified by Android project files in the workspace
+        log(logger, Messages.FINDING_PROJECT_PREREQUISITES());
+        Collection<String> platforms = build.getWorkspace().act(new ProjectPlatformFinder(listener));
+        if (platforms == null || platforms.isEmpty()) {
+            // Nothing to install, but that's ok
+            log(logger, Messages.NO_PROJECTS_FOUND());
+            return true;
+        }
+
+        // Discover Android SDK
+        AndroidSdk androidSdk = getAndroidSdk(build, launcher, listener);
+        if (androidSdk == null) {
+            log(logger, Messages.SDK_TOOLS_NOT_FOUND());
+            return false;
+        }
+
+        // Install platform(s)
+        log(logger, Messages.ENSURING_PLATFORMS_INSTALLED(platforms));
+        for (String platform : platforms) {
+            SdkInstaller.installPlatform(logger, launcher, androidSdk, platform);
+        }
+
+        // Done!
+        return true;
+    }
+
+    /** FileCallable to determine Android target projects specified in a given directory. */
+    private static final class ProjectPlatformFinder implements FileCallable<Collection<String>> {
+
+        private BuildListener listener;
+        private transient PrintStream logger;
+
+        ProjectPlatformFinder(BuildListener listener) {
+            this.listener = listener;
+        }
+
+        public Collection<String> invoke(File workspace, VirtualChannel channel)
+                throws IOException, InterruptedException {
+            if (logger == null) {
+                logger = listener.getLogger();
+            }
+
+            // Find the appropriate file: project.properties or default.properties
+            final String[] filePatterns = { "**/default.properties", "**/project.properties" };
+            DirectoryScanner scanner = new DirectoryScanner();
+            scanner.setBasedir(workspace);
+            scanner.setIncludes(filePatterns);
+            scanner.scan();
+
+            // Extract platform from each config file
+            Collection<String> platforms = new HashSet<String>();
+            String[] files = scanner.getIncludedFiles();
+            if (files != null) {
+                for (String filename : files) {
+                    String platform = getPlatformFromProjectFile(logger, new File(workspace, filename));
+                    if (platform != null) {
+                        log(logger, Messages.PROJECT_HAS_PLATFORM(filename, platform));
+                        platforms.add(platform);
+                    }
+                }
+            }
+
+            return platforms;
+        }
+
+        private static String getPlatformFromProjectFile(PrintStream logger, File f) {
+            String platform = null;
+            try {
+                // Read configured target platform from file
+                platform = Utils.parseConfigFile(f).get("target");
+                if (platform != null) {
+                    platform = platform.trim();
+                }
+            } catch (IOException e) {
+                log(logger, Messages.READING_PROJECT_FILE_FAILED(), e);
+                e.printStackTrace();
+            }
+            return platform;
+        }
+
+        private static final long serialVersionUID = 1L;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends Descriptor<Builder> implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        public DescriptorImpl() {
+            super(ProjectPrerequisitesInstaller.class);
+        }
+
+        @Override
+        public String getHelpFile() {
+            return "/plugin/android-emulator/help-installPrerequisites.html";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.INSTALL_PREREQUISITES();
+        }
+
+    }
+
+}

--- a/src/main/resources/hudson/plugins/android_emulator/Messages.properties
+++ b/src/main/resources/hudson/plugins/android_emulator/Messages.properties
@@ -60,7 +60,7 @@ PLATFORM_IMAGE_NOT_FOUND=Cannot find desired platform image at ''{0}''
 # Execution
 WAITING_FOR_EMULATOR=Waiting for the configured Android emulator to become available
 ERROR_MISCONFIGURED=Cannot start Android emulator due to misconfiguration: {0}
-SDK_TOOLS_NOT_FOUND=Cannot start emulator: required Android tools not found in PATH
+SDK_TOOLS_NOT_FOUND=Required Android tools not found in PATH; cannot continue
 USING_PATH=[none found; relying on PATH]
 USING_SDK=Using Android SDK: {0}
 CANNOT_START_EMULATOR=Cannot start Android emulator: {0}
@@ -111,6 +111,12 @@ LOAD_EMULATOR_SNAPSHOT=Load an Android emulator snapshot
 LOADING_SNAPSHOT=Loading snapshot ''{0}'' into emulator on port {1}...
 SAVE_EMULATOR_SNAPSHOT=Save an Android emulator snapshot
 SAVING_SNAPSHOT=Saving snapshot ''{0}'' for emulator on port {1}...
+INSTALL_PREREQUISITES=Install Android project prerequisites
+FINDING_PROJECT_PREREQUISITES=Searching for Android projects...
+NO_PROJECTS_FOUND=No Android projects found; won't install any dependencies.
+ENSURING_PLATFORMS_INSTALLED=Ensuring platform(s) are installed: {0}
+PROJECT_HAS_PLATFORM=Project file ''{0}'' requires platform ''{1}''
+READING_PROJECT_FILE_FAILED=Reading platform from project file failed.
 
 # Monkey
 RUN_MONKEY=Run Android monkey tester

--- a/src/main/webapp/help-installPrerequisites.html
+++ b/src/main/webapp/help-installPrerequisites.html
@@ -1,0 +1,14 @@
+Installs any platforms required to build the Android apps in this job's workspace.
+<p>
+In an Android app project, test project or library project the platform version to build against
+must be specified in either the <tt>project.properties</tt> or <tt>default.properties</tt> file, by
+setting the <tt>target</tt> parameter.
+</p>
+<p>
+This build step will search for these files in your workspace, determine which target platform(s)
+are required, and then ensure that they are installed. If the required platforms are already
+installed, no action is taken.
+<br>
+Therefore it should always be safe to run this build step before any build steps which compile an
+Android project.
+</p>


### PR DESCRIPTION
Searches for Android project properties files in the workspace,
detects the Android platform required to build those projects,
then automatically downloads and installs them.

Should be added before an 'Invoke Ant' build step or similar.