### PR TITLE
[FIXED JENKINS-34678]

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -403,7 +403,7 @@ class EmulatorConfig implements Serializable {
         // List available snapshots for this emulator
         ByteArrayOutputStream listOutput = new ByteArrayOutputStream();
         String args = String.format("-snapshot-list -no-window -avd %s", getAvdName());
-        Tool executable = androidSdk.requiresAndroidBug34233Workaround() ? Tool.EMULATOR_ARM : Tool.EMULATOR;
+        Tool executable = androidSdk.requiresAndroidBug34233Workaround() ? Tool.EMULATOR_ARM : getExecutable();
         Utils.runAndroidTool(launcher, listOutput, logger, androidSdk, executable, args, null);
 
         // Check whether a Jenkins snapshot was listed in the output


### PR DESCRIPTION
Use configured emulator executable to deal with snapshots. 

Previously this configuration option was ignored and default value - `emulator` was used.
