### PR TITLE
Improve error logging when AVD creation fails.

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -635,16 +635,18 @@ class EmulatorConfig implements Serializable {
                 errOutput = null;
             }
 
-            // Set the screen density
-            setAvdConfigValue(homeDir, "hw.lcd.density", String.valueOf(getScreenDensity().getDpi()));
-
+            // Always log any unrecognised error output. It might be important and helps to debug 
+            if (errOutput != null && errOutput.length() != 0) {
+                AndroidEmulator.log(logger, output, true);
+                AndroidEmulator.log(logger, errOutput, true);
+            }
             // Check everything went ok
             if (!avdCreated) {
-                if (errOutput != null && errOutput.length() != 0) {
-                    AndroidEmulator.log(logger, stderr.toString(), true);
-                }
                 throw new EmulatorCreationException(Messages.AVD_CREATION_FAILED());
             }
+
+            // Set the screen density
+            setAvdConfigValue(homeDir, "hw.lcd.density", String.valueOf(getScreenDensity().getDpi()));
 
             // Done!
             return false;


### PR DESCRIPTION
This will help to diagnose problems such as those found in
JENKINS-36885 however it is not a "fix" for the problem which
is more likely to be a job configuration error.

Specifically this patch always logs any stdout or stderr
output if stderr is produced and the error is not a
specifically handled case.

In addition the attempt to set the hw.lcd.density property
is delayed until the output has been generated so that it
does not prevent the logging of any diagnostic information.
