### PR TITLE
Fix for JENKINS-37614

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <artifactId>android-emulator</artifactId>
   <packaging>hpi</packaging>
-  <version>2.16-SNAPSHOT</version>
+  <version>2.17-SNAPSHOT</version>
   <name>Android Emulator Plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Android+Emulator+Plugin</url>
   <developers>

--- a/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
@@ -118,9 +118,17 @@
               default="0" />
           <f:description>${%Wait this many seconds before attempting to start the emulator}</f:description>
         </f:entry>
+        <f:entry title="${%Adb timeout}" help="/plugin/android-emulator/help-adbTimeout.html">
+          <f:textbox name="android-emulator.adbTimeout" value="${instance.adbTimeout}" style="width:4em"/>
+          <f:description>${%Wait this many seconds for ADB to be available}</f:description>
+        </f:entry>
         <f:entry title="${%Startup timeout}" help="/plugin/android-emulator/help-startupTimeout.html">
           <f:textbox name="android-emulator.startupTimeout" value="${instance.startupTimeout}" style="width:4em"/>
           <f:description>${%Wait this many seconds before aborting the startup of the emulator}</f:description>
+        </f:entry>
+        <f:entry title="${%Process kill timeout}" help="/plugin/android-emulator/help-processKillTimeout.html">
+          <f:textbox name="android-emulator.processKillTimeout" value="${instance.processKillTimeout}" style="width:4em"/>
+          <f:description>${%Wait this many seconds for process to be killed}</f:description>
         </f:entry>
         <f:entry title="${%Emulator options}" help="/plugin/android-emulator/help-commandLineOptions.html">
           <f:textbox name="android-emulator.commandLineOptions" value="${instance.commandLineOptions}" />

--- a/src/main/webapp/help-adbTimeout.html
+++ b/src/main/webapp/help-adbTimeout.html
@@ -1,0 +1,5 @@
+This determines how long the Android Emulator plugin should wait for ADB to become available before starting the Emulator.
+<p>
+    This is useful, for example, if starting the ADB takes some considerable time - for instance on the slow systems.
+    By default the plugin waits for 60 seconds.<br/>
+</p>

--- a/src/main/webapp/help-processKillTimeout.html
+++ b/src/main/webapp/help-processKillTimeout.html
@@ -1,0 +1,5 @@
+This determines how long the Android Emulator plugin should wait for the emulator processes to be confirmed as killed.
+<p>
+    This is useful, for example, if on the slow system killing the processes takes some considerable time.
+    By default the plugin waits for 10 seconds.<br/>
+</p>


### PR DESCRIPTION
It is was reported and i experienced it as well first hand, that plugin intermittently fails to start the emulator with the following error:

> [android] Emulator did not appear to start; giving up

It appears, that depending on the speed of the system it might take longer than hardcoded value of 60 seconds to fire up ADB.
The proposed changes allow to set the ADB and process kill timeout via front end to ensure that emulator is started in the slow environment.