### PR TITLE
Properly escape property values when writing on Windows

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -290,21 +290,9 @@ class EmulatorConfig implements Serializable {
         return Utils.parseConfigFile(configFile);
     }
 
-    private void writeAvdConfigFile(File homeDir, Map<String,String> values) throws FileNotFoundException {
-        StringBuilder sb = new StringBuilder();
-
-        for (String key : values.keySet()) {
-            sb.append(key);
-            sb.append("=");
-            sb.append(values.get(key));
-            sb.append("\r\n");
-        }
-
+    private void writeAvdConfigFile(File homeDir, Map<String,String> values) throws IOException {
         File configFile = new File(getAvdDirectory(homeDir), "config.ini");
-        PrintWriter out = new PrintWriter(configFile);
-        out.print(sb.toString());
-        out.flush();
-        out.close();
+        Utils.writeConfigFile(configFile, values);
     }
 
     /**

--- a/src/main/java/hudson/plugins/android_emulator/util/Utils.java
+++ b/src/main/java/hudson/plugins/android_emulator/util/Utils.java
@@ -493,6 +493,19 @@ public class Utils {
         return values;
     }
 
+    public static void writeConfigFile(File configFile, Map<String, String> values) throws IOException {
+        Properties sb = new Properties();
+
+        for (String key : values.keySet()) {
+            sb.setProperty(key, values.get(key));
+        }
+
+        PrintWriter out = new PrintWriter(configFile);
+        sb.store(out, null);
+        out.flush();
+        out.close();
+    }
+
     /**
      * Expands the variable in the given string to its value in the environment variables available
      * to this build.  The Jenkins-specific build variables for this build are then substituted.


### PR DESCRIPTION
The java.util.Properties class used in parseConfigFile unescapes the values on Windows, while the code that writes the file does not escape them again. This leads to corrupted config files after one cycle of reading and writing.

Write code has also been moved to Utils and now matches the read method.

This should also fix the problem encountered in #40.