### PR TITLE
[FIXED JENKINS-45456] Reduce Java warnings of the plugin and remove u…

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -13,7 +13,6 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.model.Computer;
-import hudson.model.Hudson;
 import hudson.model.Node;
 import hudson.model.Result;
 import hudson.plugins.android_emulator.sdk.AndroidSdk;
@@ -27,6 +26,7 @@ import hudson.util.ArgumentListBuilder;
 import hudson.util.ForkOutputStream;
 import hudson.util.FormValidation;
 import hudson.util.NullStream;
+import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
@@ -44,7 +44,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
-import java.io.Reader;
 import java.io.Serializable;
 import java.io.StringWriter;
 import java.net.ServerSocket;
@@ -173,7 +172,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
             throws IOException, InterruptedException {
         final PrintStream logger = listener.getLogger();
         if (descriptor == null) {
-            descriptor = Hudson.getInstance().getDescriptorByType(DescriptorImpl.class);
+            descriptor = Jenkins.getInstance().getDescriptorByType(DescriptorImpl.class);
         }
 
         // Substitute environment and build variables into config

--- a/src/main/java/hudson/plugins/android_emulator/TaskDispatcher.java
+++ b/src/main/java/hudson/plugins/android_emulator/TaskDispatcher.java
@@ -4,7 +4,6 @@ import hudson.Extension;
 import hudson.matrix.MatrixConfiguration;
 import hudson.model.BuildableItemWithBuildWrappers;
 import hudson.model.Executor;
-import hudson.model.Hudson;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.Queue.BuildableItem;
@@ -15,6 +14,7 @@ import hudson.model.queue.QueueTaskDispatcher;
 import hudson.model.queue.SubTask;
 
 import hudson.plugins.android_emulator.AndroidEmulator.DescriptorImpl;
+import jenkins.model.Jenkins;
 
 /**
  * This QueueTaskDispatcher prevents any one Android emulator instance from being executed more than
@@ -43,13 +43,13 @@ public class TaskDispatcher extends QueueTaskDispatcher {
         }
 
         // If the AndroidEmulator uses workspace-local emulators, we don't care.
-        DescriptorImpl descriptor = Hudson.getInstance().getDescriptorByType(DescriptorImpl.class);
+        DescriptorImpl descriptor = Jenkins.getInstance().getDescriptorByType(DescriptorImpl.class);
         if (descriptor != null && descriptor.shouldKeepInWorkspace) {
           return null;
         }
 
         // Check for builds in the queue which have the same emulator config as this task
-        Queue queue = Hudson.getInstance().getQueue();
+        Queue queue = Jenkins.getInstance().getQueue();
         for (BuildableItem item : queue.getBuildableItems()) {
             Task queuedTask = item.task;
             if (task == queuedTask) {

--- a/src/main/java/hudson/plugins/android_emulator/builder/AbstractBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/builder/AbstractBuilder.java
@@ -7,7 +7,6 @@ import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Computer;
 import hudson.model.EnvironmentContributingAction;
-import hudson.model.Hudson;
 import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.plugins.android_emulator.AndroidEmulator;
@@ -22,6 +21,7 @@ import hudson.remoting.VirtualChannel;
 import hudson.tasks.Builder;
 import hudson.util.ForkOutputStream;
 import jenkins.MasterToSlaveFileCallable;
+import jenkins.model.Jenkins;
 import net.dongliu.apk.parser.ApkParser;
 import net.dongliu.apk.parser.bean.ApkMeta;
 
@@ -55,7 +55,7 @@ public abstract class AbstractBuilder extends Builder {
             BuildListener listener) throws IOException, InterruptedException {
         boolean shouldInstallSdk = true;
         boolean keepInWorkspace = false;
-        DescriptorImpl descriptor = Hudson.getInstance().getDescriptorByType(DescriptorImpl.class);
+        DescriptorImpl descriptor = Jenkins.getInstance().getDescriptorByType(DescriptorImpl.class);
         if (descriptor != null) {
             shouldInstallSdk = descriptor.shouldInstallSdk;
             keepInWorkspace = descriptor.shouldKeepInWorkspace;
@@ -290,6 +290,8 @@ public abstract class AbstractBuilder extends Builder {
      */
     private static String getPackageIdForApk(FilePath apkPath) throws IOException, InterruptedException {
         return apkPath.act(new MasterToSlaveFileCallable<String>() {
+            private static final long serialVersionUID = 1L;
+
             public String invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
                 return getApkMetadata(f).getPackageName();
             }

--- a/src/main/java/hudson/plugins/android_emulator/builder/UpdateProjectBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/builder/UpdateProjectBuilder.java
@@ -163,6 +163,8 @@ public class UpdateProjectBuilder extends AbstractBuilder {
     private static String getWorkspacePath(FilePath workspace) throws IOException,
             InterruptedException {
         return workspace.act(new MasterToSlaveFileCallable<String>() {
+            private static final long serialVersionUID = 1L;
+
             public String invoke(File f, VirtualChannel channel) throws IOException {
                 return f.getCanonicalPath();
             }

--- a/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyRecorder.java
+++ b/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyRecorder.java
@@ -148,7 +148,7 @@ public class MonkeyRecorder extends Recorder {
         }
 
         @Override
-        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+        public boolean isApplicable(@SuppressWarnings("rawtypes") Class<? extends AbstractProject> jobType) {
             return true;
         }
 

--- a/src/main/java/hudson/plugins/android_emulator/snapshot/SnapshotLoadBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/snapshot/SnapshotLoadBuilder.java
@@ -1,6 +1,5 @@
 package hudson.plugins.android_emulator.snapshot;
 
-import hudson.Extension;
 import hudson.Functions;
 import hudson.model.Descriptor;
 import hudson.plugins.android_emulator.Messages;

--- a/src/main/java/hudson/plugins/android_emulator/snapshot/SnapshotSaveBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/snapshot/SnapshotSaveBuilder.java
@@ -1,6 +1,5 @@
 package hudson.plugins.android_emulator.snapshot;
 
-import hudson.Extension;
 import hudson.Functions;
 import hudson.model.Descriptor;
 import hudson.plugins.android_emulator.Messages;

--- a/src/main/java/hudson/plugins/android_emulator/util/Utils.java
+++ b/src/main/java/hudson/plugins/android_emulator/util/Utils.java
@@ -51,6 +51,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 
 import static hudson.plugins.android_emulator.AndroidEmulator.log;
@@ -58,7 +59,6 @@ import static hudson.plugins.android_emulator.AndroidEmulator.log;
 public class Utils {
 
     private static final Logger LOGGER = Logger.getLogger(Utils.class.getName());
-    private static final Pattern REVISION = Pattern.compile("(\\d++).*");
 
     /**
      * Retrieves the configured Android SDK root directory.
@@ -66,7 +66,7 @@ public class Utils {
      * @return The configured Android SDK root, if any. May include un-expanded variables.
      */
     public static String getConfiguredAndroidHome() {
-        DescriptorImpl descriptor = Hudson.getInstance().getDescriptorByType(DescriptorImpl.class);
+        DescriptorImpl descriptor = Jenkins.getInstance().getDescriptorByType(DescriptorImpl.class);
         if (descriptor != null) {
             return descriptor.androidHome;
         }
@@ -219,7 +219,7 @@ public class Utils {
      */
     public static ValidationResult validateAndroidHome(File sdkRoot, boolean fromWebConfig) {
         // This can be used to check the existence of a file on the server, so needs to be protected
-        if (fromWebConfig && !Hudson.getInstance().hasPermission(Hudson.ADMINISTER)) {
+        if (fromWebConfig && !Jenkins.getInstance().hasPermission(Hudson.ADMINISTER)) {
             return ValidationResult.ok();
         }
 

--- a/src/main/java/hudson/plugins/android_emulator/util/ValidationResult.java
+++ b/src/main/java/hudson/plugins/android_emulator/util/ValidationResult.java
@@ -52,9 +52,10 @@ public class ValidationResult implements Serializable {
             } else {
                 return FormValidation.error(message);
             }
+        case OK:
+        default:
+            return FormValidation.ok();
         }
-
-        return FormValidation.ok();
     }
 
     public boolean isFatal() {


### PR DESCRIPTION
I was patching the source code of the plugin to add an feature. Therefore I also reduced (one is still missing) the Java warnings in the source code.
Those are of the type: Unused imports, unused variable, deprecated Hudson.getInstance(), missing UUID, missing option in switch.