### PR TITLE
43557 Do not force classic engine with the latest build tools

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -128,7 +128,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
 
     /**
      * A hash representing the variables that are used to determine which emulator configuration
-     * should be started to fulfil the job configuration.
+     * should be started to fulfill the job configuration.
      *
      * @param node The Node on which the emulator would be run.
      * @return A hash representing the emulator configuration for this instance.
@@ -139,10 +139,10 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
 
     /**
      * A hash representing the variables that are used to determine which emulator configuration
-     * should be started to fulfil the job configuration.
+     * should be started to fulfill the job configuration.
      *
      * @param node The Node on which the emulator would be run.
-     * @param combination The matrix combination values used to expand emulator config variables.
+     * @param combination The matrix combination values used to expand emulator configuration variables.
      * @return A hash representing the emulator configuration for this instance.
      */
     public String getConfigHash(Node node, Combination combination) {
@@ -358,7 +358,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
         // Prepare to capture and log emulator standard output
         ByteArrayOutputStream emulatorOutput = new ByteArrayOutputStream();
         ForkOutputStream emulatorLogger = new ForkOutputStream(logger, emulatorOutput);
-
+        
         final Proc emulatorProcess = emu.getToolProcStarter(emuConfig.getExecutable(), emulatorArgs)
                 .stdout(emulatorLogger).stderr(logger).start();
         emu.setProcess(emulatorProcess);
@@ -371,7 +371,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
             log(logger, Messages.EMULATOR_ALREADY_IN_USE(emuConfig.getAvdName()));
             return null;
         }
-
+        
         // Sitting on the socket appears to break adb. If you try and do this you always end up with device offline.
         // A much better way is to use report-console to tell us what the port is (and hence when its available). So
         // we now do this. adb is also now clever enough to figure out that the emulator is booting and will thus

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -338,7 +338,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
 
         // Compile complete command for starting emulator
         final String emulatorArgs = emuConfig.getCommandArguments(snapshotState,
-                androidSdk.supportsSnapshots(), androidSdk.supportsEmulatorEngineFlag(),
+                androidSdk.supportsSnapshots(), androidSdk.useEngineClassicFlag(),
                 emu.userPort(), emu.adbPort(), emu.getEmulatorCallbackPort(),
                 ADB_CONNECT_TIMEOUT_MS / 1000);
 
@@ -358,7 +358,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
         // Prepare to capture and log emulator standard output
         ByteArrayOutputStream emulatorOutput = new ByteArrayOutputStream();
         ForkOutputStream emulatorLogger = new ForkOutputStream(logger, emulatorOutput);
-        
+
         final Proc emulatorProcess = emu.getToolProcStarter(emuConfig.getExecutable(), emulatorArgs)
                 .stdout(emulatorLogger).stderr(logger).start();
         emu.setProcess(emulatorProcess);
@@ -371,7 +371,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
             log(logger, Messages.EMULATOR_ALREADY_IN_USE(emuConfig.getAvdName()));
             return null;
         }
-        
+
         // Sitting on the socket appears to break adb. If you try and do this you always end up with device offline.
         // A much better way is to use report-console to tell us what the port is (and hence when its available). So
         // we now do this. adb is also now clever enough to figure out that the emulator is booting and will thus

--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -333,7 +333,7 @@ class EmulatorConfig implements Serializable {
      * @return A string of command line arguments.
      */
     public String getCommandArguments(SnapshotState snapshotState, boolean sdkSupportsSnapshots,
-            boolean emulatorSupportsEngineFlag, int userPort, int adbPort, int callbackPort,
+            boolean useEngineClassicFlag, int userPort, int adbPort, int callbackPort,
             int consoleTimeout) {
         StringBuilder sb = new StringBuilder();
 
@@ -342,7 +342,7 @@ class EmulatorConfig implements Serializable {
         // nor can we use the "-prop" or "-report-console" command line flags that we require.
         //
         // See Android bugs 202762, 202853, 205202 and 205204
-        if (emulatorSupportsEngineFlag) {
+        if (useEngineClassicFlag) {
             sb.append(" -engine classic");
         }
 

--- a/src/main/java/hudson/plugins/android_emulator/sdk/AndroidSdk.java
+++ b/src/main/java/hudson/plugins/android_emulator/sdk/AndroidSdk.java
@@ -28,9 +28,6 @@ public class AndroidSdk implements Serializable {
 
     /** First version that has an emulator which recognises the "-engine" flag. */
     private static final int SDK_EMULATOR_ENGINE_FLAG = 25;
-    
-    /** First version where classic engine cannot start. */
-    private static final int SDK_EMULATOR_ENGINE_FLAG_NOT_WORKING = 26;
 
     private final String sdkRoot;
     private final String sdkHome;
@@ -98,9 +95,12 @@ public class AndroidSdk implements Serializable {
         return getSdkToolsMajorVersion() >= SDK_SYSTEM_IMAGE_NEW_FORMAT;
     }
 
-    /** @return {@code true} if this SDK has an emulator that supports the "-engine" flag. */
-    public boolean supportsEmulatorEngineFlag() {
-        return getSdkToolsMajorVersion() >= SDK_EMULATOR_ENGINE_FLAG && getSdkToolsMajorVersion() < SDK_EMULATOR_ENGINE_FLAG_NOT_WORKING;
+    /** @return {@code true} if this SDK has an emulator that supports the "-engine" flag
+      * and we can workaround Android bugs 202762, 202853, 205202 and 205204 with the usage
+      * of the classic engine.
+      */
+    public boolean useEngineClassicFlag() {
+        return getSdkToolsMajorVersion() == SDK_EMULATOR_ENGINE_FLAG;
     }
 
     /** {@return true} if we should explicitly select a non-64-bit emulator executable for snapshot-related tasks. */

--- a/src/main/java/hudson/plugins/android_emulator/sdk/AndroidSdk.java
+++ b/src/main/java/hudson/plugins/android_emulator/sdk/AndroidSdk.java
@@ -28,6 +28,9 @@ public class AndroidSdk implements Serializable {
 
     /** First version that has an emulator which recognises the "-engine" flag. */
     private static final int SDK_EMULATOR_ENGINE_FLAG = 25;
+    
+    /** First version where classic engine cannot start. */
+    private static final int SDK_EMULATOR_ENGINE_FLAG_NOT_WORKING = 26;
 
     private final String sdkRoot;
     private final String sdkHome;
@@ -97,7 +100,7 @@ public class AndroidSdk implements Serializable {
 
     /** @return {@code true} if this SDK has an emulator that supports the "-engine" flag. */
     public boolean supportsEmulatorEngineFlag() {
-        return getSdkToolsMajorVersion() >= SDK_EMULATOR_ENGINE_FLAG;
+        return getSdkToolsMajorVersion() >= SDK_EMULATOR_ENGINE_FLAG && getSdkToolsMajorVersion() < SDK_EMULATOR_ENGINE_FLAG_NOT_WORKING;
     }
 
     /** {@return true} if we should explicitly select a non-64-bit emulator executable for snapshot-related tasks. */


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-43557

Solves the "PANIC: Missing emulator engine program for 'x86' CPU" problem. Tested with the latest emulator and previous emu where this problem didn't exist.