### PR TITLE
Update system image component name construction for APIs >= 25

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/SdkInstaller.java
+++ b/src/main/java/hudson/plugins/android_emulator/SdkInstaller.java
@@ -343,7 +343,9 @@ public class SdkInstaller {
         // Even if a system image doesn't exist for this platform, the installer silently ignores it
         if (dependentPlatform >= 10 && abi != null) {
             if (sdk.supportsSystemImageNewFormat()) {
-                String tag = "android";
+                // Adjust for API levels >= 25, where only images with Google API support are
+                // available, and the naming convention changes slightly
+                String tag = dependentPlatform >= 25 ? "google_apis" : "android";
                 int slash = abi.indexOf('/');
                 if (slash > 0 && slash < abi.length() - 1) {
                     tag = abi.substring(0, slash);


### PR DESCRIPTION
The naming convention for Android system images changes slightly beginning
at level 25; this updates the component name constructor logic so that the
desired image is found.

N.B. Based on the images available via the Device Manager GUI and on
searching around the web, it looks like only system images with Google API
support are available for these API levels.

Bug: https://phabricator.wikimedia.org/T150623
Change-Id: I9c42dfc0d8ee662440fcdd1668007d0931a7b2b3