### PR TITLE
[Test] Stop forcing QEMU 1 use with the "-engine classic" flag

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -338,9 +338,8 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
 
         // Compile complete command for starting emulator
         final String emulatorArgs = emuConfig.getCommandArguments(snapshotState,
-                androidSdk.supportsSnapshots(), androidSdk.supportsEmulatorEngineFlag(),
-                emu.userPort(), emu.adbPort(), emu.getEmulatorCallbackPort(),
-                ADB_CONNECT_TIMEOUT_MS / 1000);
+                androidSdk.supportsSnapshots(), emu.userPort(), emu.adbPort(),
+                emu.getEmulatorCallbackPort(), ADB_CONNECT_TIMEOUT_MS / 1000);
 
         // Start emulator process
         if (snapshotState == SnapshotState.BOOT) {

--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -333,18 +333,8 @@ class EmulatorConfig implements Serializable {
      * @return A string of command line arguments.
      */
     public String getCommandArguments(SnapshotState snapshotState, boolean sdkSupportsSnapshots,
-            boolean emulatorSupportsEngineFlag, int userPort, int adbPort, int callbackPort,
-            int consoleTimeout) {
+            int userPort, int adbPort, int callbackPort, int consoleTimeout) {
         StringBuilder sb = new StringBuilder();
-
-        // Stick to using the original version of the emulator for now, as otherwise we can't use
-        // the "-ports" command line flag, which we need to stay outside of the regular port range,
-        // nor can we use the "-prop" or "-report-console" command line flags that we require.
-        //
-        // See Android bugs 202762, 202853, 205202 and 205204
-        if (emulatorSupportsEngineFlag) {
-            sb.append(" -engine classic");
-        }
 
         // Tell the emulator to use certain ports
         sb.append(String.format(" -ports %s,%s", userPort, adbPort));
@@ -520,8 +510,8 @@ class EmulatorConfig implements Serializable {
             // Overwrite any existing files
             args.append("-f ");
 
-            // Initialise snapshot support, regardless of whether we will actually use it
-            if (androidSdk.supportsSnapshots()) {
+            // Initialise snapshot support
+            if (shouldUseSnapshots() && androidSdk.supportsSnapshots()) {
                 args.append("-a ");
             }
 

--- a/src/main/java/hudson/plugins/android_emulator/sdk/AndroidSdk.java
+++ b/src/main/java/hudson/plugins/android_emulator/sdk/AndroidSdk.java
@@ -95,11 +95,6 @@ public class AndroidSdk implements Serializable {
         return getSdkToolsMajorVersion() >= SDK_SYSTEM_IMAGE_NEW_FORMAT;
     }
 
-    /** @return {@code true} if this SDK has an emulator that supports the "-engine" flag. */
-    public boolean supportsEmulatorEngineFlag() {
-        return getSdkToolsMajorVersion() >= SDK_EMULATOR_ENGINE_FLAG;
-    }
-
     /** {@return true} if we should explicitly select a non-64-bit emulator executable for snapshot-related tasks. */
     public boolean requiresAndroidBug34233Workaround() {
         if (sdkToolsVersion == null) {


### PR DESCRIPTION
For builds in which the Android SDK tools are at major version 25 or
higher, the upstream Jenkins Android emulator plugin adds the command-
line option "-engine classic"[1] when creating the Android virtual device,
in order to force QEMU 1 use. Unfortunately, this is hard-coded to
happen based on the build environment rather than being exposed as a user-
configurable option. This was apparently intended to work around a bug in
which the -ports option was unavailable when using QEMU 2, though that bug
has reportedly since been fixed.[2]

The plugin unconditionally creates the AVD with snapshot support but the
emulator would then force select the classic engine. Only add snapshot
support (android created avd -a) when the job requests it.

I believe the "-engine classic" option may be behind our boot timeout
issues as that trouble started with the previous emulator around the time
we bumped our SDK tooling to level 25. This patch is intended to test that
hypothesis.

[1] https://developer.android.com/studio/run/emulator-commandline.html
[2] https://issues.jenkins-ci.org/browse/JENKINS-40178

Change-Id: I0e46f14f0986f9982cdf17b65820b6cd79423477