### PR TITLE
Fix non-default (google apis) image handling

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/Constants.java
+++ b/src/main/java/hudson/plugins/android_emulator/Constants.java
@@ -257,6 +257,10 @@ class AndroidPlatform implements Serializable {
             return name;
         }
 
+        return getAndroidTargetName();
+    }
+
+    public String getAndroidTargetName() {
         return AndroidPlatform.getTargetName(level);
     }
 

--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -523,7 +523,7 @@ class EmulatorConfig implements Serializable {
             final SdkCliCommand sdkCreateAvdCmd = SdkCliCommandFactory.getCommandsForSdk(androidSdk)
                     .getCreatedAvdCommand(getAvdName(), androidSdk.supportsSnapshots(),
                             sdCardSize, screenResolution.getSkinName(), deviceDefinition,
-                            osVersion.getTargetName(), osVersion.getPackagePathOfSystemImage(targetAbi),
+                            osVersion.getAndroidTargetName(), osVersion.getPackagePathOfSystemImage(targetAbi),
                             osVersion.getTagFromAbiString(targetAbi));
             boolean isUnix = !Functions.isWindows();
             ArgumentListBuilder builder = Utils.getToolCommand(androidSdk, isUnix, sdkCreateAvdCmd);

--- a/src/main/java/hudson/plugins/android_emulator/SdkInstaller.java
+++ b/src/main/java/hudson/plugins/android_emulator/SdkInstaller.java
@@ -352,7 +352,7 @@ public class SdkInstaller {
 
         // Add dependent platform (eg: 'android-17')
         if (androidPlatform.getSdkLevel() > 0) {
-            components.add(androidPlatform.getTargetName());
+            components.add(androidPlatform.getAndroidTargetName());
         }
 
         // Add system image, if required

--- a/src/main/java/hudson/plugins/android_emulator/sdk/cli/SdkToolsCommands17To25_2.java
+++ b/src/main/java/hudson/plugins/android_emulator/sdk/cli/SdkToolsCommands17To25_2.java
@@ -86,6 +86,11 @@ public class SdkToolsCommands17To25_2 extends SdkToolsCommandsCurrentBase implem
         args.append(" -t ");
         args.append(androidTarget);
 
+        if (tag != null && !tag.isEmpty()) {
+            args.append(" --tag ");
+            args.append(tag);
+        }
+
         return new SdkCliCommand(Tool.ANDROID_LEGACY, args.toString());
     }
 

--- a/src/test/java/hudson/plugins/android_emulator/AndroidPlatformTest.java
+++ b/src/test/java/hudson/plugins/android_emulator/AndroidPlatformTest.java
@@ -28,13 +28,6 @@ public class AndroidPlatformTest extends TestCase {
     }
 
     @Test
-    public void testCreateAddonPlatform() {
-        final String name = "Some:Addon:11";
-        AndroidPlatform platform = AndroidPlatform.valueOf(name);
-        assertEquals(name, platform.getTargetName());
-    }
-
-    @Test
     public void testCreateInvalidPlatform() {
         assertNull(AndroidPlatform.valueOf(null));
 
@@ -100,6 +93,7 @@ public class AndroidPlatformTest extends TestCase {
 
     @Test
     public void testTargetName() {
+        assertEquals("Some:Addon:11", AndroidPlatform.valueOf("Some:Addon:11").getTargetName());
         assertEquals("Google Inc.:Google APIs:23", AndroidPlatform.valueOf("Google Inc.:Google APIs:23").getTargetName());
         assertEquals("Google Inc.:Google APIs:24", AndroidPlatform.valueOf("Google Inc.:Google APIs:24").getTargetName());
         assertEquals("Apple Inc.:Apple APIs:24", AndroidPlatform.valueOf("Apple Inc.:Apple APIs:24").getTargetName());
@@ -109,6 +103,19 @@ public class AndroidPlatformTest extends TestCase {
         assertEquals("android-10", AndroidPlatform.valueOf("2.3.3").getTargetName());
         assertEquals("android-26", AndroidPlatform.valueOf("8.0").getTargetName());
         assertEquals("android-26", AndroidPlatform.valueOf("26").getTargetName());
+    }
+
+    @Test
+    public void testAndroidTargetName() {
+        assertEquals("android-23", AndroidPlatform.valueOf("Google Inc.:Google APIs:23").getAndroidTargetName());
+        assertEquals("android-24", AndroidPlatform.valueOf("Google Inc.:Google APIs:24").getAndroidTargetName());
+        assertEquals("android-24", AndroidPlatform.valueOf("Apple Inc.:Apple APIs:24").getAndroidTargetName());
+        assertEquals("android-23", AndroidPlatform.valueOf("android-23").getAndroidTargetName());
+        assertEquals("android-24", AndroidPlatform.valueOf("android-24").getAndroidTargetName());
+        assertEquals("android-26", AndroidPlatform.valueOf("android-26").getAndroidTargetName());
+        assertEquals("android-10", AndroidPlatform.valueOf("2.3.3").getAndroidTargetName());
+        assertEquals("android-26", AndroidPlatform.valueOf("8.0").getAndroidTargetName());
+        assertEquals("android-26", AndroidPlatform.valueOf("26").getAndroidTargetName());
     }
 
     @Test

--- a/src/test/java/hudson/plugins/android_emulator/sdk/cli/SdkCommandsTest.java
+++ b/src/test/java/hudson/plugins/android_emulator/sdk/cli/SdkCommandsTest.java
@@ -234,7 +234,7 @@ public class SdkCommandsTest {
                         "android-23", null, null);
         final SdkCliCommand createAvdWithSdCardCmdV04 = SdkCliCommandFactory.getCommandsForSdk("4")
                 .getCreatedAvdCommand("test04", false, "200M", "test", null,
-                        "android-23", null, null);
+                        "android-23", null, "default");
 
         assertEquals(Tool.AVDMANAGER, createAvdWithSdCardCmdV25_3.getTool());
         assertEquals(Tool.ANDROID_LEGACY, createAvdWithSdCardCmdV25.getTool());
@@ -242,9 +242,33 @@ public class SdkCommandsTest {
         assertEquals(Tool.ANDROID_LEGACY, createAvdWithSdCardCmdV04.getTool());
 
         assertEquals("create avd -f -c 100M -d 4 -n test25 -k system-images;android-24;default;x86_64", createAvdWithSdCardCmdV25_3.getArgs());
-        assertEquals("create avd -f -c 100M -s null -n test25 -t android-23", createAvdWithSdCardCmdV25.getArgs());
+        assertEquals("create avd -f -c 100M -s null -n test25 -t android-23 --tag test", createAvdWithSdCardCmdV25.getArgs());
         assertEquals("create avd -f -a -c 1G -s 1x1 -n test17 -t android-23", createAvdWithSdCardCmdV17.getArgs());
-        assertEquals("create avd -f -c 200M -s test -n test04 -t android-23", createAvdWithSdCardCmdV04.getArgs());
+        assertEquals("create avd -f -c 200M -s test -n test04 -t android-23 --tag default", createAvdWithSdCardCmdV04.getArgs());
+
+        // Google APIs
+        final SdkCliCommand createAvdGoogleApiCmdV25_3 = SdkCliCommandFactory.getCommandsForSdk("25.3")
+                .getCreatedAvdCommand("test25", false, null, "dummy", "9",
+                        null, "system-images;android-24;google_apis;x86_64", "google_apis");
+        final SdkCliCommand createAvdGoogleApiCmdV25 = SdkCliCommandFactory.getCommandsForSdk("25")
+                .getCreatedAvdCommand("test25", false, null, "dummy", "9",
+                        "Google Inc.:Google APIs:23", "system-images;android-24;google_apis;x86_64", "google_apis");
+        final SdkCliCommand createAvdGoogleApiCmdV17 = SdkCliCommandFactory.getCommandsForSdk("17")
+                .getCreatedAvdCommand("test17", false, null, "768x1024", null,
+                        "Google Inc.:Google APIs:23", null, "google_apis");
+        final SdkCliCommand createAvdGoogleApiCmdV04 = SdkCliCommandFactory.getCommandsForSdk("4")
+                .getCreatedAvdCommand("test04", false, null, "1080x1920", "7",
+                        "Google Inc.:Google APIs:23", null, "google_apis");
+
+        assertEquals(Tool.AVDMANAGER, createAvdGoogleApiCmdV25_3.getTool());
+        assertEquals(Tool.ANDROID_LEGACY, createAvdGoogleApiCmdV25.getTool());
+        assertEquals(Tool.ANDROID_LEGACY, createAvdGoogleApiCmdV17.getTool());
+        assertEquals(Tool.ANDROID_LEGACY, createAvdGoogleApiCmdV04.getTool());
+
+        assertEquals("create avd -f -d 9 -n test25 -k system-images;android-24;google_apis;x86_64 --tag google_apis", createAvdGoogleApiCmdV25_3.getArgs());
+        assertEquals("create avd -f -s dummy -n test25 -t Google Inc.:Google APIs:23 --tag google_apis", createAvdGoogleApiCmdV25.getArgs());
+        assertEquals("create avd -f -s 768x1024 -n test17 -t Google Inc.:Google APIs:23 --tag google_apis", createAvdGoogleApiCmdV17.getArgs());
+        assertEquals("create avd -f -s 1080x1920 -n test04 -t Google Inc.:Google APIs:23 --tag google_apis", createAvdGoogleApiCmdV04.getArgs());
     }
 
     @Test


### PR DESCRIPTION
Fixed downloading of the correct platform for non-default (eg. Google APIs) images with SDK tools >= 25.3.
Fixed creation of non-default (eg. Google APIs) AVDs with older SDK tools <= 25.2. Fixes JENKINS-32737.