### PR TITLE
Fix/suppress findbugs warnings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 // Build on ci.jenkins.io; see https://github.com/jenkins-infra/pipeline-library
-buildPlugin(platforms: ['linux'], findbugs: [run: false])
+buildPlugin(platforms: ['linux'])

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -39,6 +39,8 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -101,6 +103,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
 
 
     @DataBoundConstructor
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public AndroidEmulator(String avdName, String osVersion, String screenDensity,
             String screenResolution, String deviceLocale, String sdCardSize,
             HardwareProperty[] hardwareProperties, boolean wipeData, boolean showWindow,
@@ -150,6 +153,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
      * @param combination The matrix combination values used to expand emulator config variables.
      * @return A hash representing the emulator configuration for this instance.
      */
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public String getConfigHash(Node node, Combination combination) {
         EnvVars envVars;
         try {
@@ -292,6 +296,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
         return doSetUp(build, launcher, listener, androidSdk, emuConfig, expandedProperties);
     }
 
+    @SuppressFBWarnings({"NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "DM_DEFAULT_ENCODING"})
     private Environment doSetUp(final AbstractBuild<?, ?> build, final Launcher launcher,
             final BuildListener listener, final AndroidSdk androidSdk,
             final EmulatorConfig emuConfig, final HardwareProperty[] hardwareProperties)
@@ -727,6 +732,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
      * @param emu The emulator context
      * @return <code>true</code> if the emulator has booted, <code>false</code> if we timed-out.
      */
+    @SuppressFBWarnings({"DM_DEFAULT_ENCODING", "ICAST_IDIV_CAST_TO_DOUBLE"})
     private boolean waitForBootCompletion(final boolean ignoreProcess,
             final int timeout, EmulatorConfig config, AndroidEmulatorContext emu) {
         long start = System.currentTimeMillis();
@@ -1119,6 +1125,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
             this.timeout = timeout;
         }
 
+        @SuppressFBWarnings("DM_DEFAULT_ENCODING")
         public Integer call() throws InterruptedException {
             ServerSocket socket = null;
             try {

--- a/src/main/java/hudson/plugins/android_emulator/BuildNodeUnavailableException.java
+++ b/src/main/java/hudson/plugins/android_emulator/BuildNodeUnavailableException.java
@@ -1,0 +1,13 @@
+package hudson.plugins.android_emulator;
+
+import java.io.IOException;
+
+public class BuildNodeUnavailableException extends IOException {
+
+    public BuildNodeUnavailableException() {
+        super(Messages.NODE_UNAVAILABLE_EXCEPTION());
+    }
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/src/main/java/hudson/plugins/android_emulator/Constants.java
+++ b/src/main/java/hudson/plugins/android_emulator/Constants.java
@@ -7,12 +7,15 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public interface Constants {
 
     /** The locale to which Android emulators default if not otherwise specified. */
     static final String DEFAULT_LOCALE = "en_US";
 
     /** Locales supported: http://developer.android.com/sdk/android-3.0.html#locs */
+    @SuppressFBWarnings("MS_OOI_PKGPROTECT")
     static final String[] EMULATOR_LOCALES = {
         "ar_EG", "ar_IL", "bg_BG", "ca_ES", "cs_CZ", "da_DK", "de_AT", "de_CH",
         "de_DE", "de_LI", "el_GR", "en_AU", "en_CA", "en_GB", "en_IE", "en_IN",
@@ -25,6 +28,7 @@ public interface Constants {
     };
 
     /** Commonly-used hardware properties that can be emulated. */
+    @SuppressFBWarnings("MS_OOI_PKGPROTECT")
     static final String[] HARDWARE_PROPERTIES = {
         "hw.accelerometer", "hw.battery", "hw.camera", "hw.dPad", "hw.gps",
         "hw.gsmModem", "hw.keyboard", "hw.ramSize", "hw.sdCard",
@@ -32,6 +36,7 @@ public interface Constants {
     };
 
     /** Common ABIs. */
+    @SuppressFBWarnings("MS_OOI_PKGPROTECT")
     static final String[] TARGET_ABIS = {
         "armeabi", "armeabi-v7a", "mips", "x86", "x86_64"
     };

--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -17,6 +17,8 @@ import hudson.plugins.android_emulator.util.Utils;
 import hudson.remoting.Callable;
 import hudson.util.ArgumentListBuilder;
 
+import static hudson.plugins.android_emulator.AndroidEmulator.log;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -427,7 +429,7 @@ class EmulatorConfig implements Serializable {
      * {@code FALSE} if an AVD was newly created, and throws an AndroidEmulatorException if the
      * given AVD or parts required to generate a new AVD were not found.
      */
-    @SuppressFBWarnings({"DM_DEFAULT_ENCODING", "RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"})
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     private final class EmulatorCreationTask extends MasterToSlaveCallable<Boolean, AndroidEmulatorException> {
 
         private static final long serialVersionUID = 1L;
@@ -472,7 +474,9 @@ class EmulatorConfig implements Serializable {
 
                     // We should ensure that we start out with a clean SD card for the build
                     if (sdCardRequired && sdCardFile.exists()) {
-                        sdCardFile.delete();
+                        if (!sdCardFile.delete()) {
+                            log(logger, Messages.FAILED_TO_DELETE_FILE(sdCardFile.getAbsolutePath()));
+                        }
                     }
                 }
 
@@ -734,7 +738,6 @@ class EmulatorConfig implements Serializable {
     }
 
     /** A task that deletes the AVD corresponding to our local state. */
-    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
     private final class EmulatorDeletionTask extends MasterToSlaveCallable<Boolean, Exception> {
 
         private static final long serialVersionUID = 1L;
@@ -764,7 +767,10 @@ class EmulatorConfig implements Serializable {
             new FilePath(avdDirectory).deleteRecursive();
 
             // Delete the metadata file
-            getAvdMetadataFile().delete();
+            final File avdMetaDataFile = getAvdMetadataFile();
+            if (!avdMetaDataFile.delete()) {
+                log(logger, Messages.FAILED_TO_DELETE_FILE(avdMetaDataFile.getAbsolutePath()));
+            }
 
             // Success!
             return true;

--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -713,8 +713,7 @@ class EmulatorConfig implements Serializable {
     }
 
     /** Writes an empty emulator auth file. */
-    @SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC")
-    private final class EmulatorAuthFileTask extends MasterToSlaveCallable<Void, IOException> {
+    private static final class EmulatorAuthFileTask extends MasterToSlaveCallable<Void, IOException> {
 
         private static final long serialVersionUID = 1L;
 

--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -709,7 +709,7 @@ class EmulatorConfig implements Serializable {
     }
 
     /** Writes an empty emulator auth file. */
-    @SuppressFBWarnings({"SIC_INNER_SHOULD_BE_STATIC", "VA_FORMAT_STRING_EXTRA_ARGUMENTS_PASSED"})
+    @SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC")
     private final class EmulatorAuthFileTask extends MasterToSlaveCallable<Void, IOException> {
 
         private static final long serialVersionUID = 1L;
@@ -722,9 +722,9 @@ class EmulatorConfig implements Serializable {
                     FilePath authFile = new FilePath(userHome).child(".emulator_console_auth_token");
                     authFile.write("", "UTF-8");
                 } catch (IOException e) {
-                    throw new IOException(String.format("Failed to write auth file to %s.", userHome, e));
+                    throw new IOException(String.format("Failed to write auth file to %s.%n%s", userHome, e.getMessage()));
                 } catch (InterruptedException e) {
-                    throw new IOException(String.format("Interrupted while writing auth file to %s.", userHome, e));
+                    throw new IOException(String.format("Interrupted while writing auth file to %s.%n%s", userHome, e.getMessage()));
                 }
             }
 

--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -572,7 +572,7 @@ class EmulatorConfig implements Serializable {
             }
 
             final OutputStream procstdin = process.getOutputStream();
-            final StdoutReader procstdout = new StdoutReader(process.getInputStream());
+            final StdoutReader procstdout = StdoutReader.createAndRunAsyncReader(process.getInputStream());
 
             // Command may prompt us whether we want to further customise the AVD.
             // Just "press" Enter to continue with the selected target's defaults.

--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -29,6 +29,8 @@ import jenkins.security.MasterToSlaveCallable;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 class EmulatorConfig implements Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -402,6 +404,7 @@ class EmulatorConfig implements Serializable {
      * @throws IOException If execution of the emulator command fails.
      * @throws InterruptedException If execution of the emulator command is interrupted.
      */
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     public boolean hasExistingSnapshot(Launcher launcher, AndroidSdk androidSdk)
             throws IOException, InterruptedException {
         final PrintStream logger = launcher.getListener().getLogger();
@@ -424,6 +427,7 @@ class EmulatorConfig implements Serializable {
      * {@code FALSE} if an AVD was newly created, and throws an AndroidEmulatorException if the
      * given AVD or parts required to generate a new AVD were not found.
      */
+    @SuppressFBWarnings({"DM_DEFAULT_ENCODING", "RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"})
     private final class EmulatorCreationTask extends MasterToSlaveCallable<Boolean, AndroidEmulatorException> {
 
         private static final long serialVersionUID = 1L;
@@ -705,6 +709,7 @@ class EmulatorConfig implements Serializable {
     }
 
     /** Writes an empty emulator auth file. */
+    @SuppressFBWarnings({"SIC_INNER_SHOULD_BE_STATIC", "VA_FORMAT_STRING_EXTRA_ARGUMENTS_PASSED"})
     private final class EmulatorAuthFileTask extends MasterToSlaveCallable<Void, IOException> {
 
         private static final long serialVersionUID = 1L;
@@ -729,6 +734,7 @@ class EmulatorConfig implements Serializable {
     }
 
     /** A task that deletes the AVD corresponding to our local state. */
+    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
     private final class EmulatorDeletionTask extends MasterToSlaveCallable<Boolean, Exception> {
 
         private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/plugins/android_emulator/InstallBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/InstallBuilder.java
@@ -63,7 +63,7 @@ public class InstallBuilder extends AbstractBuilder {
     }
 
     @Override
-    @SuppressFBWarnings({"NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "DM_DEFAULT_ENCODING"})
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
         final PrintStream logger = listener.getLogger();
@@ -83,7 +83,11 @@ public class InstallBuilder extends AbstractBuilder {
 
         // Get absolute path to the APK file
         String apkFileExpanded = Utils.expandVariables(build, listener, apkFile);
-        FilePath apkPath = build.getWorkspace().child(apkFileExpanded);
+        final FilePath workspace = build.getWorkspace();
+        if (workspace == null) {
+            throw new BuildNodeUnavailableException();
+        }
+        final FilePath apkPath = workspace.child(apkFileExpanded);
 
         // Check whether the file exists
         boolean exists = apkPath.exists();

--- a/src/main/java/hudson/plugins/android_emulator/InstallBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/InstallBuilder.java
@@ -20,6 +20,8 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -61,6 +63,7 @@ public class InstallBuilder extends AbstractBuilder {
     }
 
     @Override
+    @SuppressFBWarnings({"NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "DM_DEFAULT_ENCODING"})
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
         final PrintStream logger = listener.getLogger();

--- a/src/main/java/hudson/plugins/android_emulator/SdkInstaller.java
+++ b/src/main/java/hudson/plugins/android_emulator/SdkInstaller.java
@@ -549,7 +549,6 @@ public class SdkInstaller {
             this.listener = listener;
         }
 
-        @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
         public Void call() throws Exception {
             if (logger == null) {
                 logger = listener.getLogger();
@@ -557,7 +556,9 @@ public class SdkInstaller {
 
             final File homeDir = Utils.getAndroidSdkHomeDirectory(androidSdkHome);
             final File androidDir = new File(homeDir, ".android");
-            androidDir.mkdirs();
+            if (!androidDir.mkdirs()) {
+                log(logger, Messages.FAILED_TO_CREATE_FILE(androidDir.getAbsolutePath()));
+            }
 
             File configFile = new File(androidDir, "ddms.cfg");
             PrintWriter out;

--- a/src/main/java/hudson/plugins/android_emulator/SdkInstaller.java
+++ b/src/main/java/hudson/plugins/android_emulator/SdkInstaller.java
@@ -23,6 +23,8 @@ import jenkins.MasterToSlaveFileCallable;
 import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.lang.StringUtils;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -68,6 +70,7 @@ public class SdkInstaller {
         }
     }
 
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private static AndroidSdk doInstall(Launcher launcher, BuildListener listener, String androidSdkHome)
             throws SdkInstallationException, IOException, InterruptedException {
         // We should install the SDK on the current build machine
@@ -124,6 +127,7 @@ public class SdkInstaller {
     }
 
     @SuppressWarnings("serial")
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private static AndroidSdk getAndroidSdkForNode(Node node, final String androidHome,
             final String androidSdkHome) throws IOException, InterruptedException {
         return node.getChannel().call(new MasterToSlaveCallable<AndroidSdk, IOException>() {
@@ -133,6 +137,7 @@ public class SdkInstaller {
         });
     }
 
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     private static String getBuildToolsPackageName(PrintStream logger, Launcher launcher, AndroidSdk sdk)
     throws IOException, InterruptedException {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
@@ -195,6 +200,7 @@ public class SdkInstaller {
      * @param sdk Root of the SDK installation to install components for.
      * @param components Name of the component(s) to install.
      */
+    @SuppressFBWarnings({"DM_DEFAULT_ENCODING", "OS_OPEN_STREAM"})
     private static void installComponent(PrintStream logger, Launcher launcher, AndroidSdk sdk,
             final List<String> components) throws IOException, InterruptedException {
         String proxySettings = getProxySettings();
@@ -315,6 +321,7 @@ public class SdkInstaller {
         }
     }
 
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     private static boolean isPlatformInstalled(PrintStream logger, Launcher launcher,
             AndroidSdk sdk, String platform, String abi,
             final boolean skipSystemInstall) throws IOException, InterruptedException {
@@ -434,6 +441,7 @@ public class SdkInstaller {
      *
      * @return The semaphore for the current machine, which must be released once finished with.
      */
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private static Semaphore acquireLock() throws InterruptedException {
         // Retrieve the lock for this node
         Semaphore semaphore;
@@ -464,6 +472,7 @@ public class SdkInstaller {
      * @param sdkRoot Root directory of the SDK installation to check.
      * @return {@code true} if the basic SDK <b>and</b> all required SDK components are installed.
      */
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private static boolean isSdkInstallComplete(Node node, final String sdkRoot)
             throws IOException, InterruptedException {
         // Validation needs to run on the remote node
@@ -512,6 +521,7 @@ public class SdkInstaller {
     }
 
     /** Helper to run SDK statistics opt-out task on a remote node. */
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     private static final class StatsOptOutTask extends MasterToSlaveCallable<Void, Exception> {
 
         private static final long serialVersionUID = 1L;
@@ -525,6 +535,7 @@ public class SdkInstaller {
             this.listener = listener;
         }
 
+        @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
         public Void call() throws Exception {
             if (logger == null) {
                 logger = listener.getLogger();
@@ -573,6 +584,7 @@ public class SdkInstaller {
             return null;
         }
 
+        @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
         static AndroidInstaller fromNode(Node node) throws SdkUnavailableException,
                 IOException, InterruptedException {
             return node.getChannel().call(new MasterToSlaveCallable<AndroidInstaller, SdkUnavailableException>() {

--- a/src/main/java/hudson/plugins/android_emulator/SdkInstaller.java
+++ b/src/main/java/hudson/plugins/android_emulator/SdkInstaller.java
@@ -200,7 +200,7 @@ public class SdkInstaller {
      * @param sdk Root of the SDK installation to install components for.
      * @param components Name of the component(s) to install.
      */
-    @SuppressFBWarnings({"DM_DEFAULT_ENCODING", "OS_OPEN_STREAM"})
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     private static void installComponent(PrintStream logger, Launcher launcher, AndroidSdk sdk,
             final List<String> components) throws IOException, InterruptedException {
         String proxySettings = getProxySettings();
@@ -222,14 +222,18 @@ public class SdkInstaller {
         // Run the command and accept any licence requests during installation
         Proc proc = procStarter.start();
         BufferedReader r = new BufferedReader(new InputStreamReader(proc.getStdout()));
-        String line;
-        while (proc.isAlive() && (line = r.readLine()) != null) {
-            logger.println(line);
-            if (line.toLowerCase(Locale.ENGLISH).startsWith("license id: ") ||
-                    line.toLowerCase(Locale.ENGLISH).startsWith("license android-sdk")) {
-                proc.getStdin().write("y\r\n".getBytes());
-                proc.getStdin().flush();
+        try {
+            String line;
+            while (proc.isAlive() && (line = r.readLine()) != null) {
+                logger.println(line);
+                if (line.toLowerCase(Locale.ENGLISH).startsWith("license id: ") ||
+                        line.toLowerCase(Locale.ENGLISH).startsWith("license android-sdk")) {
+                    proc.getStdin().write("y\r\n".getBytes());
+                    proc.getStdin().flush();
+                }
             }
+        } finally {
+            r.close();
         }
     }
 

--- a/src/main/java/hudson/plugins/android_emulator/TaskDispatcher.java
+++ b/src/main/java/hudson/plugins/android_emulator/TaskDispatcher.java
@@ -1,9 +1,9 @@
 package hudson.plugins.android_emulator;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.matrix.MatrixConfiguration;
 import hudson.model.BuildableItemWithBuildWrappers;
+import hudson.model.Computer;
 import hudson.model.Executor;
 import hudson.model.Node;
 import hudson.model.Queue;
@@ -35,7 +35,6 @@ import jenkins.model.Jenkins;
 public class TaskDispatcher extends QueueTaskDispatcher {
 
     @Override
-    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public CauseOfBlockage canTake(Node node, Task task) {
         // If the given task doesn't use the AndroidEmulator BuildWrapper, we don't care.
         // Or, if there is an emulator hash, but with unresolved environment variables, we shouldn't block the build
@@ -68,7 +67,12 @@ public class TaskDispatcher extends QueueTaskDispatcher {
         }
 
         // Check whether a build with this emulator config is already running on this machine
-        for (Executor e : node.toComputer().getExecutors()) {
+        final Computer computer = node.toComputer();
+        if (computer == null) {
+            return CauseOfBlockage.fromMessage(Messages._NO_EXECUTORS_ON_NODE());
+        }
+
+        for (Executor e : computer.getExecutors()) {
             Executable executable = e.getCurrentExecutable();
             if (executable == null) {
                 continue;

--- a/src/main/java/hudson/plugins/android_emulator/TaskDispatcher.java
+++ b/src/main/java/hudson/plugins/android_emulator/TaskDispatcher.java
@@ -1,5 +1,6 @@
 package hudson.plugins.android_emulator;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.matrix.MatrixConfiguration;
 import hudson.model.BuildableItemWithBuildWrappers;
@@ -34,6 +35,7 @@ import jenkins.model.Jenkins;
 public class TaskDispatcher extends QueueTaskDispatcher {
 
     @Override
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public CauseOfBlockage canTake(Node node, Task task) {
         // If the given task doesn't use the AndroidEmulator BuildWrapper, we don't care.
         // Or, if there is an emulator hash, but with unresolved environment variables, we shouldn't block the build

--- a/src/main/java/hudson/plugins/android_emulator/builder/AbstractBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/builder/AbstractBuilder.java
@@ -32,6 +32,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import static hudson.plugins.android_emulator.AndroidEmulator.log;
 
 public abstract class AbstractBuilder extends Builder {
@@ -184,6 +186,7 @@ public abstract class AbstractBuilder extends Builder {
      *
      * @return {@code true} if the process has started; {@code false} if it did not start within a reasonable timeout.
      */
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     protected boolean waitForCoreProcess(AbstractBuild<?, ?> build, Launcher launcher,
             AndroidSdk androidSdk, String deviceIdentifier) throws IOException, InterruptedException {
 
@@ -260,6 +263,7 @@ public abstract class AbstractBuilder extends Builder {
      * @throws IOException If execution failed.
      * @throws InterruptedException If execution failed.
      */
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     protected static boolean uninstallApk(AbstractBuild<?, ?> build, Launcher launcher,
             PrintStream logger, AndroidSdk androidSdk, String deviceIdentifier, String packageId)
                 throws IOException, InterruptedException {

--- a/src/main/java/hudson/plugins/android_emulator/builder/ProjectPrerequisitesInstaller.java
+++ b/src/main/java/hudson/plugins/android_emulator/builder/ProjectPrerequisitesInstaller.java
@@ -2,11 +2,13 @@ package hudson.plugins.android_emulator.builder;
 
 import static hudson.plugins.android_emulator.AndroidEmulator.log;
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.Functions;
 import hudson.Launcher;
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
 import hudson.model.AbstractBuild;
+import hudson.plugins.android_emulator.BuildNodeUnavailableException;
 import hudson.plugins.android_emulator.Messages;
 import hudson.plugins.android_emulator.SdkInstaller;
 import hudson.plugins.android_emulator.sdk.AndroidSdk;
@@ -25,8 +27,6 @@ import java.util.HashSet;
 import org.apache.tools.ant.DirectoryScanner;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class ProjectPrerequisitesInstaller extends AbstractBuilder {
 
     @DataBoundConstructor
@@ -35,14 +35,17 @@ public class ProjectPrerequisitesInstaller extends AbstractBuilder {
     }
 
     @Override
-    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
         final PrintStream logger = listener.getLogger();
 
         // Gather list of platforms specified by Android project files in the workspace
         log(logger, Messages.FINDING_PROJECTS());
-        Collection<String> platforms = build.getWorkspace().act(new ProjectPlatformFinder(listener));
+        final FilePath workspace = build.getWorkspace();
+        if (workspace == null) {
+            throw new BuildNodeUnavailableException();
+        }
+        final Collection<String> platforms = workspace.act(new ProjectPlatformFinder(listener));
         if (platforms == null || platforms.isEmpty()) {
             // Nothing to install, but that's ok
             log(logger, Messages.NO_PROJECTS_FOUND_FOR_PREREQUISITES());

--- a/src/main/java/hudson/plugins/android_emulator/builder/ProjectPrerequisitesInstaller.java
+++ b/src/main/java/hudson/plugins/android_emulator/builder/ProjectPrerequisitesInstaller.java
@@ -25,6 +25,8 @@ import java.util.HashSet;
 import org.apache.tools.ant.DirectoryScanner;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class ProjectPrerequisitesInstaller extends AbstractBuilder {
 
     @DataBoundConstructor
@@ -33,6 +35,7 @@ public class ProjectPrerequisitesInstaller extends AbstractBuilder {
     }
 
     @Override
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
         final PrintStream logger = listener.getLogger();

--- a/src/main/java/hudson/plugins/android_emulator/builder/UpdateProjectBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/builder/UpdateProjectBuilder.java
@@ -8,6 +8,7 @@ import hudson.Launcher;
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
 import hudson.model.AbstractBuild;
+import hudson.plugins.android_emulator.BuildNodeUnavailableException;
 import hudson.plugins.android_emulator.Messages;
 import hudson.plugins.android_emulator.sdk.AndroidSdk;
 import hudson.plugins.android_emulator.sdk.cli.SdkCliCommand;
@@ -90,7 +91,6 @@ public class UpdateProjectBuilder extends AbstractBuilder {
     }
 
     @Override
-    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
         final PrintStream logger = listener.getLogger();
@@ -109,7 +109,11 @@ public class UpdateProjectBuilder extends AbstractBuilder {
 
         // Gather list of projects, determined by reading Android project files in the workspace
         log(logger, Messages.FINDING_PROJECTS());
-        List<Project> projects = build.getWorkspace().act(new ProjectFinder(listener));
+        final FilePath buildWorkspace = build.getWorkspace();
+        if (buildWorkspace == null) {
+            throw new BuildNodeUnavailableException();
+        }
+        final List<Project> projects = buildWorkspace.act(new ProjectFinder(listener));
         if (projects == null || projects.isEmpty()) {
             // No projects found. Odd, but that's ok
             log(logger, Messages.NO_PROJECTS_FOUND_TO_UPDATE());
@@ -121,7 +125,7 @@ public class UpdateProjectBuilder extends AbstractBuilder {
         new ProjectPrerequisitesInstaller().perform(build, launcher, listener);
 
         // Run the appropriate command for each project found
-        final String workspace = getWorkspacePath(build.getWorkspace());
+        final String workspace = getWorkspacePath(buildWorkspace);
         for (Project project : projects) {
             log(logger, "");
 

--- a/src/main/java/hudson/plugins/android_emulator/builder/UpdateProjectBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/builder/UpdateProjectBuilder.java
@@ -41,6 +41,8 @@ import org.jvnet.localizer.Localizable;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jenkins.MasterToSlaveFileCallable;
 
 public class UpdateProjectBuilder extends AbstractBuilder {
@@ -88,6 +90,7 @@ public class UpdateProjectBuilder extends AbstractBuilder {
     }
 
     @Override
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
         final PrintStream logger = listener.getLogger();
@@ -263,6 +266,7 @@ public class UpdateProjectBuilder extends AbstractBuilder {
         }
 
         /** Determines whether the given directory contains an Android test project. */
+        @SuppressFBWarnings("DM_DEFAULT_ENCODING")
         private static boolean isTestProject(PrintStream logger, File projectDir) {
             File manifest = new File(projectDir, "AndroidManifest.xml");
             try {

--- a/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyBuilder.java
@@ -19,6 +19,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -78,6 +80,7 @@ public class MonkeyBuilder extends AbstractBuilder {
     }
 
     @Override
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
         final PrintStream logger = listener.getLogger();
@@ -158,6 +161,7 @@ public class MonkeyBuilder extends AbstractBuilder {
         }
     }
 
+    @SuppressFBWarnings("DMI_RANDOM_USED_ONLY_ONCE")
     private static long parseSeed(String seed) {
         long seedValue;
         if ("random".equals(seed)) {

--- a/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyBuilder.java
@@ -21,8 +21,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -40,6 +38,9 @@ public class MonkeyBuilder extends AbstractBuilder {
 
     /** File to write monkey results to if none specified. */
     private static final String DEFAULT_OUTPUT_FILENAME = "monkey.txt";
+
+    /** Random if string radom is used as seed */
+    private static Random random;
 
     /** File to write monkey results to. */
     @Exported
@@ -166,11 +167,10 @@ public class MonkeyBuilder extends AbstractBuilder {
         }
     }
 
-    @SuppressFBWarnings("DMI_RANDOM_USED_ONLY_ONCE")
     private static long parseSeed(String seed) {
         long seedValue;
         if ("random".equals(seed)) {
-            seedValue = new Random().nextLong();
+            seedValue = getNextLongFromRandom();
         } else if ("timestamp".equals(seed)) {
             seedValue = System.currentTimeMillis();
         } else if (seed != null) {
@@ -183,6 +183,13 @@ public class MonkeyBuilder extends AbstractBuilder {
             seedValue = 0;
         }
         return seedValue;
+    }
+
+    private synchronized static long getNextLongFromRandom() {
+        if (random == null) {
+            random = new Random();
+        }
+        return random.nextLong();
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyBuilder.java
@@ -1,12 +1,14 @@
 package hudson.plugins.android_emulator.monkey;
 
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.Functions;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
 import hudson.model.TaskListener;
+import hudson.plugins.android_emulator.BuildNodeUnavailableException;
 import hudson.plugins.android_emulator.Messages;
 import hudson.plugins.android_emulator.builder.AbstractBuilder;
 import hudson.plugins.android_emulator.sdk.AndroidSdk;
@@ -80,7 +82,6 @@ public class MonkeyBuilder extends AbstractBuilder {
     }
 
     @Override
-    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
         final PrintStream logger = listener.getLogger();
@@ -117,7 +118,11 @@ public class MonkeyBuilder extends AbstractBuilder {
         }
 
         // Start monkeying around
-        OutputStream monkeyOutput = build.getWorkspace().child(outputFile).write();
+        final FilePath workspace = build.getWorkspace();
+        if (workspace == null) {
+            throw new BuildNodeUnavailableException();
+        }
+        final OutputStream monkeyOutput = workspace.child(outputFile).write();
         try {
             log(logger, Messages.STARTING_MONKEY(packageNamesLog, eventCount, seedValue, categoryNamesLog));
             Utils.runAndroidTool(launcher, build.getEnvironment(TaskListener.NULL), monkeyOutput,

--- a/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyRecorder.java
+++ b/src/main/java/hudson/plugins/android_emulator/monkey/MonkeyRecorder.java
@@ -25,6 +25,8 @@ import java.util.regex.Pattern;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.export.Exported;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class MonkeyRecorder extends Recorder {
 
     /** Default file to read monkey results from. */
@@ -45,6 +47,7 @@ public class MonkeyRecorder extends Recorder {
     }
 
     @Override
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
         // Don't analyse anything if the build failed

--- a/src/main/java/hudson/plugins/android_emulator/sdk/Tool.java
+++ b/src/main/java/hudson/plugins/android_emulator/sdk/Tool.java
@@ -3,6 +3,8 @@ package hudson.plugins.android_emulator.sdk;
 import java.util.ArrayList;
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public enum Tool {
     ADB("adb", ".exe", new PlatformToolLocator()),
     ANDROID_LEGACY("android", ".bat"),
@@ -17,6 +19,7 @@ public enum Tool {
     SDKMANAGER("sdkmanager", ".bat", new SdkToolLocator()),
     MKSDCARD("mksdcard", ".exe");
 
+    @SuppressFBWarnings("MS_MUTABLE_ARRAY")
     public static Tool[] EMULATORS = new Tool[] { EMULATOR,
            EMULATOR_ARM,   EMULATOR_MIPS,   EMULATOR_X86,
            EMULATOR64_ARM, EMULATOR64_MIPS, EMULATOR64_X86

--- a/src/main/java/hudson/plugins/android_emulator/sdk/ToolLocator.java
+++ b/src/main/java/hudson/plugins/android_emulator/sdk/ToolLocator.java
@@ -1,5 +1,7 @@
 package hudson.plugins.android_emulator.sdk;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public interface ToolLocator {
     public static final String BUILD_TOOLS_DIR = "build-tools";
     public static final String EMULATOR_DIR = "emulator";
@@ -8,10 +10,12 @@ public interface ToolLocator {
     public static final String TOOLS_DIR = "tools";
     public static final String TOOLS_BIN_DIR = "tools/bin";
 
+    @SuppressFBWarnings("MS_MUTABLE_ARRAY")
     public static final String[] SDK_DIRECTORIES_LEGACY = {
             TOOLS_DIR, PLATFORM_TOOLS_DIR
     };
 
+    @SuppressFBWarnings("MS_MUTABLE_ARRAY")
     public static final String[] SDK_DIRECTORIES = {
             EMULATOR_DIR, PLATFORM_TOOLS_DIR, TOOLS_DIR, TOOLS_BIN_DIR
     };

--- a/src/main/java/hudson/plugins/android_emulator/util/ConfigFileUtils.java
+++ b/src/main/java/hudson/plugins/android_emulator/util/ConfigFileUtils.java
@@ -11,6 +11,7 @@ import java.util.Properties;
 
 import org.apache.commons.io.FilenameUtils;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.plugins.android_emulator.Messages;
 
 import java.util.Map.Entry;
@@ -46,6 +47,7 @@ public class ConfigFileUtils {
      * @return The key-value pairs contained in the file, ignoring any comments or blank lines.
      * @throws IOException If the file could not be read.
      */
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     private static Map<String, String> parsePropertiesFile(File configFile) throws IOException {
         final FileReader fileReader = new FileReader(configFile);
         final BufferedReader reader = new BufferedReader(fileReader);
@@ -68,6 +70,7 @@ public class ConfigFileUtils {
      * @return The key-value pairs contained in the file, ignoring any comments or blank lines.
      * @throws IOException If the file could not be read.
      */
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     private static Map<String, String> parseSimpleINIFormatFile(File configFile) throws IOException {
         final Map<String, String> values = new HashMap<String, String>();
 
@@ -126,6 +129,7 @@ public class ConfigFileUtils {
      * @param values configuration key-value-pairs to write.
      * @throws IOException If the file could not be written.
      */
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     private static void writeConfigFilePropertiesFormat(final File configFile, final Map<String,String> values) throws IOException {
         final Properties props = new Properties();
 
@@ -146,6 +150,7 @@ public class ConfigFileUtils {
      * @param values configuration key-value-pairs to write
      * @throws IOException If the file could not be written.
      */
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     private static void writeConfigFileSimpleINIFormat(final File configFile, final Map<String,String> values) throws IOException {
         PrintWriter out = new PrintWriter(configFile);
         for (final Entry<String, String> entry : values.entrySet()) {

--- a/src/main/java/hudson/plugins/android_emulator/util/StdoutReader.java
+++ b/src/main/java/hudson/plugins/android_emulator/util/StdoutReader.java
@@ -8,14 +8,12 @@ import java.util.Arrays;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 /**
  * Reads to contents of an InputStream in an background thread,
  * useful to retrieve OutputStream/ErrorStream of a Process, and
  * allows retrieval as String representing a line of the output.
  */
-public class StdoutReader
+public final class StdoutReader
 {
     /**
      * InputStream to read data from
@@ -39,19 +37,23 @@ public class StdoutReader
      */
     final AtomicBoolean closed = new AtomicBoolean(false);
 
+    private StdoutReader(final InputStream inputStream) {
+        this.stdout = inputStream;
+    }
+
     /**
      * Creates a new StdoutReader starting to read the data
      * immediately of the given InputStream in an own thread.
      * @param inputStream InputStream to read the data from
      */
-    @SuppressFBWarnings("SC_START_IN_CTOR")
-    public StdoutReader(final InputStream inputStream) {
-        this.stdout = inputStream;
-        if (this.stdout != null) {
-            runner.start();
+    public static StdoutReader createAndRunAsyncReader(final InputStream inputStream) {
+        final StdoutReader instance = new StdoutReader(inputStream);
+        if (instance.stdout != null) {
+            instance.runner.start();
         } else {
-            closed.set(true);
+            instance.closed.set(true);
         }
+        return instance;
     }
 
     final Thread runner = new Thread(new Runnable() {

--- a/src/main/java/hudson/plugins/android_emulator/util/StdoutReader.java
+++ b/src/main/java/hudson/plugins/android_emulator/util/StdoutReader.java
@@ -8,6 +8,8 @@ import java.util.Arrays;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Reads to contents of an InputStream in an background thread,
  * useful to retrieve OutputStream/ErrorStream of a Process, and
@@ -42,6 +44,7 @@ public class StdoutReader
      * immediately of the given InputStream in an own thread.
      * @param inputStream InputStream to read the data from
      */
+    @SuppressFBWarnings("SC_START_IN_CTOR")
     public StdoutReader(final InputStream inputStream) {
         this.stdout = inputStream;
         if (this.stdout != null) {

--- a/src/main/java/hudson/plugins/android_emulator/util/Utils.java
+++ b/src/main/java/hudson/plugins/android_emulator/util/Utils.java
@@ -310,7 +310,6 @@ public class Utils {
      * @param fromWebConfig Whether we are being called from the web config and should be more lax.
      * @return Whether the SDK looks valid or not (or a warning if the SDK install is incomplete).
      */
-    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public static ValidationResult validateAndroidHome(final File sdkRoot, final boolean allowLegacy, final boolean fromWebConfig) {
 
         // This can be used to check the existence of a file on the server, so needs to be protected
@@ -344,7 +343,8 @@ public class Utils {
 
         // Give the user a nice warning (not error) if they've not downloaded any platforms yet
         File platformsDir = new File(sdkRoot, ToolLocator.PLATFORMS_DIR);
-        if (platformsDir.list() == null || platformsDir.list().length == 0) {
+        final String[] platformsDirList = platformsDir.list();
+        if (platformsDirList == null || platformsDirList.length == 0) {
             return ValidationResult.warning(Messages.SDK_PLATFORMS_EMPTY());
         }
 

--- a/src/main/java/hudson/plugins/android_emulator/util/Utils.java
+++ b/src/main/java/hudson/plugins/android_emulator/util/Utils.java
@@ -617,7 +617,6 @@ public class Utils {
      * @param timeoutMs How long to wait for before cancelling the attempt to kill the process.
      * @return {@code true} if the process was killed successfully.
      */
-    @SuppressFBWarnings("REC_CATCH_EXCEPTION")
     public static boolean killProcess(final Proc process, final int timeoutMs) {
         Boolean result = null;
         FutureTask<Boolean> task = null;
@@ -633,7 +632,9 @@ public class Utils {
             // Execute the task asynchronously and wait for a result or timeout
             Executors.newSingleThreadExecutor().execute(task);
             result = task.get(timeoutMs, TimeUnit.MILLISECONDS);
-        } catch (Exception e) {
+        } catch (TimeoutException ex) {
+        } catch (InterruptedException ex) {
+        } catch (ExecutionException ex) {
             // Ignore
         } finally {
             if (task != null && !task.isDone()) {

--- a/src/main/java/hudson/plugins/android_emulator/util/Utils.java
+++ b/src/main/java/hudson/plugins/android_emulator/util/Utils.java
@@ -25,11 +25,9 @@ import hudson.remoting.Future;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.VersionNumber;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.filefilter.IOFileFilter;
-import org.apache.commons.io.filefilter.NameFileFilter;
-import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.commons.lang.exception.ExceptionUtils;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -312,6 +310,7 @@ public class Utils {
      * @param fromWebConfig Whether we are being called from the web config and should be more lax.
      * @return Whether the SDK looks valid or not (or a warning if the SDK install is incomplete).
      */
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public static ValidationResult validateAndroidHome(final File sdkRoot, final boolean allowLegacy, final boolean fromWebConfig) {
 
         // This can be used to check the existence of a file on the server, so needs to be protected
@@ -618,6 +617,7 @@ public class Utils {
      * @param timeoutMs How long to wait for before cancelling the attempt to kill the process.
      * @return {@code true} if the process was killed successfully.
      */
+    @SuppressFBWarnings("REC_CATCH_EXCEPTION")
     public static boolean killProcess(final Proc process, final int timeoutMs) {
         Boolean result = null;
         FutureTask<Boolean> task = null;
@@ -906,6 +906,7 @@ public class Utils {
         }
 
         @SuppressWarnings("null")
+        @SuppressFBWarnings({"DM_DEFAULT_ENCODING", "RV_DONT_JUST_NULL_CHECK_READLINE"})
         public Boolean call() throws IOException {
             Socket socket = null;
             BufferedReader in = null;

--- a/src/main/resources/hudson/plugins/android_emulator/Messages.properties
+++ b/src/main/resources/hudson/plugins/android_emulator/Messages.properties
@@ -65,7 +65,7 @@ PLATFORM_IMAGE_NOT_FOUND=Cannot find desired platform image at ''{0}''
 
 # Execution
 WAITING_FOR_EMULATOR=Waiting for the configured Android emulator to become available
-NO_EXECUTORS_ON_NODE=Can't run build on node, as there seems to be no executor available
+NO_EXECUTORS_ON_NODE=Can''t run build on node, as there seems to be no executor available
 EMULATOR_CONSOLE_REPORT=Emulator reported that the console is available on port {0}
 EMULATOR_STATE_REPORT=Emulator reported that the startup process is ''{0}''
 ERROR_MISCONFIGURED=Cannot start Android emulator due to misconfiguration: {0}

--- a/src/main/resources/hudson/plugins/android_emulator/Messages.properties
+++ b/src/main/resources/hudson/plugins/android_emulator/Messages.properties
@@ -65,6 +65,7 @@ PLATFORM_IMAGE_NOT_FOUND=Cannot find desired platform image at ''{0}''
 
 # Execution
 WAITING_FOR_EMULATOR=Waiting for the configured Android emulator to become available
+NO_EXECUTORS_ON_NODE=Can't run build on node, as there seems to be no executor available
 EMULATOR_CONSOLE_REPORT=Emulator reported that the console is available on port {0}
 EMULATOR_STATE_REPORT=Emulator reported that the startup process is ''{0}''
 ERROR_MISCONFIGURED=Cannot start Android emulator due to misconfiguration: {0}
@@ -97,6 +98,7 @@ EMULATOR_IS_READY=Emulator is ready for use (took {0} seconds)
 STOPPING_EMULATOR=Stopping Android emulator
 EMULATOR_SHUTDOWN_FAILED=Failed to shut down emulator; the process may still be running...
 ARCHIVING_LOG=Archiving emulator log
+NODE_UNAVAILABLE_EXCEPTION=Build node seems to be unavailable: channel/node/computer is null.
 
 # Deletion
 AVD_DIRECTORY_NOT_FOUND=Could not find AVD directory ''{0}''

--- a/src/main/resources/hudson/plugins/android_emulator/Messages.properties
+++ b/src/main/resources/hudson/plugins/android_emulator/Messages.properties
@@ -103,6 +103,7 @@ NODE_UNAVAILABLE_EXCEPTION=Build node seems to be unavailable: channel/node/comp
 # Deletion
 AVD_DIRECTORY_NOT_FOUND=Could not find AVD directory ''{0}''
 FAILED_TO_DELETE_AVD=Failed to delete AVD: {0}
+FAILED_TO_DELETE_FILE=Failed to delete file or directory: {0}
 
 # Command execution
 SENDING_COMMAND_FAILED=Failed to execute emulator command ''{0}'': {1}
@@ -144,6 +145,7 @@ READING_PROJECT_FILE_FAILED=Reading platform from project file failed:
 FAILED_TO_DETERMINE_PROJECT_TYPE=Failed to determine type of project at ''{0}''.
 MANIFEST_XPATH_FAILURE=Failed to evaluate XPath for manifest at ''{0}''. Please report this as a bug!
 FAILED_TO_READ_MANIFEST=Failed to read manifest file at ''{0}''.
+FAILED_TO_CREATE_FILE=Failed to create file or directory: {0}
 
 # Monkey
 RUN_MONKEY=Run Android monkey tester


### PR DESCRIPTION
This PR fixes some of the existing Findbugs warnings, the still remaining are suppressed.

The following types are only suppressed and not fixed:
- DM_DEFAULT_ENCODING: Most streams/readers (mostly for stdout/stdin) are using the default encoding, didn't want to change the current behavior
- EI_EXPOSE_REP2, MS_OOI_PKGPROTECT, MS_MUTABLE_ARRAY: Arrays accessible, and therefore modifiable (even if marked as final) from outside. Used for `@Exported` marked fields, didn't want to break if changed to a list.
- ICAST_IDIV_CAST_TO_DOUBLE: Could be easily fixed, but didn't want to change timeout-behavior ( int division ( / 1000) vs double division ( / 1000.0 )
- RV_DONT_JUST_NULL_CHECK_READLINE: intentional and reasonable code