### PR TITLE
[JENKINS-51197] Fix failure if the latest available build-tools version is a RC.

### DIFF
--- a/src/test/java/hudson/plugins/android_emulator/sdk/cli/SdkCommandsTestData.java
+++ b/src/test/java/hudson/plugins/android_emulator/sdk/cli/SdkCommandsTestData.java
@@ -348,6 +348,34 @@ public interface SdkCommandsTestData {
             "    Description:        Android SDK Build-Tools 26.0.1\n" + 
             "    Version:            26.0.1\n" + 
             "\n" + 
+            "build-tools;26.0.2\n" +
+            "    Description:        Android SDK Build-Tools 26.0.2\n" +
+            "    Version:            26.0.2\n" +
+            "\n" +
+            "build-tools;26.0.3\n" +
+            "    Description:        Android SDK Build-Tools 26.0.3\n" +
+            "    Version:            26.0.3\n" +
+            "\n" +
+            "build-tools;27.0.0\n" +
+            "    Description:        Android SDK Build-Tools 27\n" +
+            "    Version:            27.0.0\n" +
+            "\n" +
+            "build-tools;27.0.1\n" +
+            "    Description:        Android SDK Build-Tools 27.0.1\n" +
+            "    Version:            27.0.1\n" +
+            "\n" +
+            "build-tools;27.0.2\n" +
+            "    Description:        Android SDK Build-Tools 27.0.2\n" +
+            "    Version:            27.0.2\n" +
+            "\n" +
+            "build-tools;27.0.3\n" +
+            "    Description:        Android SDK Build-Tools 27.0.3\n" +
+            "    Version:            27.0.3\n" +
+            "\n" +
+            "build-tools;28.0.0-rc1\n" +
+            "    Description:        Android SDK Build-Tools 28-rc1\n" +
+            "    Version:            28.0.0 rc1\n" +
+            "\n" +
             "cmake;3.6.4111459\n" + 
             "    Description:        CMake 3.6.4111459\n" + 
             "    Version:            3.6.4111459\n" + 

--- a/src/test/java/hudson/plugins/android_emulator/util/UtilsTest.java
+++ b/src/test/java/hudson/plugins/android_emulator/util/UtilsTest.java
@@ -325,6 +325,11 @@ public class UtilsTest {
         final String versions8 = "build-tools-3.3\nbild-tools-20.1\rbuild-tools-1\r\nbuild-tools-3.1";
         final String result8 = Utils.getPatternWithHighestSuffixedVersionNumberInMultiLineInput(versions8, "dummy-tools");
         assertNull(result8);
+
+        // JENKINS-51197: do not install beta/rc versions
+        final String versions9 = "build-tools-27.0.0\nbuild-tools-27.0.1\rbuild-tools-28.0.0-rc1";
+        final String result9 = Utils.getPatternWithHighestSuffixedVersionNumberInMultiLineInput(versions9, "build-tools");
+        assertEquals("build-tools-27.0.1", result9);
     }
 
     // Workaround for Bug 64356053 ('-no-audio'-, '-noaudio'- and '-audio none'-options ignored)


### PR DESCRIPTION
Use the latest stable version for auto-installs.