### PR TITLE
Replaced deprecated Util.copy with built-in java function

### DIFF
--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Map;
 import java.util.regex.Pattern;
 import jenkins.security.MasterToSlaveCallable;
@@ -506,7 +508,11 @@ class EmulatorConfig implements Serializable {
             if (createSnapshot) {
                 // Copy the snapshots file into place
                 File snapshotDir = new File(sdkRoot, "tools/lib/emulator");
-                Util.copyFile(new File(snapshotDir, "snapshots.img"), snapshotsFile);
+                try {
+                    Files.copy(new File(snapshotDir, "snapshots.img").toPath(), snapshotsFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                } catch (IOException e) {
+                    log(logger, e.getMessage());
+                }
 
                 // Update the AVD config file mark snapshots as enabled
                 setAvdConfigValue(homeDir, "snapshot.present", "true");
@@ -663,9 +669,7 @@ class EmulatorConfig implements Serializable {
                     procBuilder.environment().put(Constants.ENV_VAR_ANDROID_SDK_HOME, androidSdkHome);
                 }
                 procBuilder.start().waitFor();
-            } catch (InterruptedException ex) {
-                return false;
-            } catch (IOException ex) {
+            } catch (InterruptedException | IOException ex) {
                 return false;
             }
 

--- a/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
+++ b/src/main/java/hudson/plugins/android_emulator/EmulatorConfig.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import jenkins.security.MasterToSlaveCallable;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -509,7 +510,7 @@ class EmulatorConfig implements Serializable {
                 // Copy the snapshots file into place
                 File snapshotDir = new File(sdkRoot, "tools/lib/emulator");
                 try {
-                    Files.copy(new File(snapshotDir, "snapshots.img").toPath(), snapshotsFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                    FileUtils.copyFile(new File(snapshotDir, "snapshots.img"), snapshotsFile);
                 } catch (IOException e) {
                     log(logger, e.getMessage());
                 }


### PR DESCRIPTION
Replaced deprecated `Util.copy` with Apache Commons Io FileUtil function. As a follow up of https://github.com/jenkinsci/jenkins/pull/6272

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
