### PR TITLE
Use https: for scm URL, not git:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     </dependencies>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/android-emulator-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/android-emulator-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/android-emulator-plugin.git</developerConnection>
         <tag>HEAD</tag>
     </scm>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~
- ~~Link to relevant pull requests, esp. upstream and downstream changes~
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

GitHub has deprecated one of the unauthenticated access protocols (`git://` protocol). The `pom.xml` section that defines the `scm` for the plugin should refer to the repository with the `https://` protocol instead of the `git://` protocol.