### PR TITLE
Remove usages of Prototype

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.7</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,18 +1,7 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin(
-  // Container agents start faster and are easier to administer
-  useContainerAgent: true,
-  // Show failures on all configurations
-  failFast: false,
-  // Opt-in to the Artifact Caching Proxy, to be removed when it will be opt-out.
-  // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
-  artifactCachingProxyEnabled: true,
-  // Test Java 11 with a recent LTS, Java 17 even more recent
-  configurations: [
-    [platform: 'linux',   jdk: '17', jenkins: '2.380'],
-    [platform: 'linux',   jdk: '11', jenkins: '2.375.1'],
-    [platform: 'windows', jdk: '11']
-  ]
-)
+buildPlugin(useContainerAgent: true, configurations: [
+  [platform: 'linux', jdk: 17],
+  [platform: 'windows', jdk: 11],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>4.71</version>
+        <relativePath />
     </parent>
 
     <artifactId>android-emulator</artifactId>
     <packaging>hpi</packaging>
-    <version>3.1.4-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <name>Android Emulator Plugin</name>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Android+Emulator+Plugin</url>
 
     <properties>
-        <jenkins.version>2.361.4</jenkins.version>
+        <revision>3.1.4</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <jenkins.version>2.387.3</jenkins.version>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 
     <developers>
@@ -34,7 +39,7 @@
     <licenses>
         <license>
             <name>The MIT License (MIT)</name>
-            <url>http://opensource.org/licenses/MIT</url>
+            <url>https://opensource.org/licenses/MIT</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -43,8 +48,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-        	      <version>2102.v854b_fec19c92</version>
+                <artifactId>bom-2.387.x</artifactId>
+                <version>2244.vd60654536b_96</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -112,9 +117,10 @@
     </dependencies>
 
     <scm>
-        <connection>scm:git:https://github.com/jenkinsci/android-emulator-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/android-emulator-plugin.git</developerConnection>
-        <tag>HEAD</tag>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
+        <tag>${scmTag}</tag>
     </scm>
 
     <repositories>
@@ -130,16 +136,4 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-
-	<build>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>com.github.spotbugs</groupId>
-					<artifactId>spotbugs-maven-plugin</artifactId>
-					<version>4.7.3.4</version>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-	</build>
 </project>

--- a/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
+++ b/src/main/java/hudson/plugins/android_emulator/AndroidEmulator.java
@@ -838,7 +838,7 @@ public class AndroidEmulator extends BuildWrapper implements Serializable {
         private static final long serialVersionUID = 1L;
 
         /**
-         * The Android SDK home directory.  Can include variables, e.g. <tt>${ANDROID_HOME}</tt>.
+         * The Android SDK home directory.  Can include variables, e.g. {@code ${ANDROID_HOME}}.
          * <p>If <code>null</code>, we will just assume the required commands are on the PATH.</p>
          */
         public String androidHome;

--- a/src/main/java/hudson/plugins/android_emulator/builder/AbstractBuilder.java
+++ b/src/main/java/hudson/plugins/android_emulator/builder/AbstractBuilder.java
@@ -131,7 +131,7 @@ public abstract class AbstractBuilder extends Builder {
      *
      * @param build The build for which we should retrieve the SDK instance.
      * @param listener The listener used to get the environment variables.
-     * @return The device identifier (defaulting to the value of "<tt>$ANDROID_AVD_DEVICE</tt>").
+     * @return The device identifier (defaulting to the value of "{@code $ANDROID_AVD_DEVICE}").
      */
     protected static String getDeviceIdentifier(AbstractBuild<?, ?> build, BuildListener listener) {
         String deviceSerial = expandVariable(build, listener, Constants.ENV_VAR_ANDROID_AVD_DEVICE);
@@ -149,7 +149,7 @@ public abstract class AbstractBuilder extends Builder {
      *
      * @param build The build for which we should retrieve the SDK instance.
      * @param listener The listener used to get the environment variables.
-     * @return The device identifier (defaulting to the value of "<tt>-s $ANDROID_AVD_DEVICE</tt>").
+     * @return The device identifier (defaulting to the value of "{@code -s $ANDROID_AVD_DEVICE}").
      */
     protected static int getDeviceTelnetPort(AbstractBuild<?, ?> build, BuildListener listener) {
         String devicePort = expandVariable(build, listener, Constants.ENV_VAR_ANDROID_AVD_USER_PORT);

--- a/src/main/java/hudson/plugins/android_emulator/util/Utils.java
+++ b/src/main/java/hudson/plugins/android_emulator/util/Utils.java
@@ -515,7 +515,7 @@ public class Utils {
      *
      * @param build  The build from which to get the build-specific and environment variables.
      * @param listener  The listener used to get the environment variables.
-     * @param token  The token which may or may not contain variables in the format <tt>${foo}</tt>.
+     * @param token  The token which may or may not contain variables in the format {@code ${foo}}.
      * @return  The given token, with applicable variable expansions done.
      */
     public static String expandVariables(AbstractBuild<?,?> build, BuildListener listener, String token) {
@@ -542,7 +542,7 @@ public class Utils {
      *
      * @param envVars  Map of the environment variables.
      * @param buildVars  Map of the build-specific variables.
-     * @param token  The token which may or may not contain variables in the format <tt>${foo}</tt>.
+     * @param token  The token which may or may not contain variables in the format {@code ${foo}}.
      * @return  The given token, with applicable variable expansions done.
      */
     public static String expandVariables(EnvVars envVars, Map<String,String> buildVars,

--- a/src/main/java/jenkins/plugin/android/emulator/sdk/cli/EmulatorCLIBuilder.java
+++ b/src/main/java/jenkins/plugin/android/emulator/sdk/cli/EmulatorCLIBuilder.java
@@ -21,7 +21,7 @@ import hudson.util.Secret;
 /**
  * Build a command line argument for emulator command.
  * 
- * @see https://developer.android.com/studio/run/emulator-commandline
+ * @see <a href="https://developer.android.com/studio/run/emulator-commandline">Start the emulator from the command line</a>
  * @author Nikolas Falco
  */
 public class EmulatorCLIBuilder {

--- a/src/main/java/jenkins/plugin/android/emulator/tools/AndroidSDKInstallation.java
+++ b/src/main/java/jenkins/plugin/android/emulator/tools/AndroidSDKInstallation.java
@@ -78,7 +78,6 @@ public class AndroidSDKInstallation extends ToolInstallation implements Environm
     /**
      * Gets a locator for CLI executables installed by this tool.
      *
-     * @param launcher a way to start processes
      * @return a locator for CLI executables for this tool
      * @throws IOException if something goes wrong
      */
@@ -167,9 +166,8 @@ public class AndroidSDKInstallation extends ToolInstallation implements Environm
             return Collections.singletonList(new AndroidSDKInstaller(null, Channel.STABLE));
         }
 
-        /*
-         * (non-Javadoc)
-         * @see hudson.tools.Descriptor#configure(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)
+        /**
+         * see {@link hudson.model.Descriptor#configure(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)}
          */
         @Override
         public boolean configure(StaplerRequest req, JSONObject json) throws hudson.model.Descriptor.FormException {

--- a/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
@@ -29,7 +29,7 @@
           <f:editableComboBox id="android-emulator.screenResolution" field="screenResolution"
               items="${descriptor.deviceResolutions}"
               checkUrl="'descriptorByName/AndroidEmulator/checkScreenResolution?value='+ escape(this.value)
-                  +'&amp;density='+ escape(Form.findMatchingInput(this,'android-emulator.screenDensity').value)
+                  +'&amp;density='+ escape(findMatchingFormInput(this,'android-emulator.screenDensity').value)
                   +'&amp;osVersion='+ escape(document.getElementById('android-emulator.osVersion').value)" />
         </f:entry>
         <f:entry title="${%Device Definition}" help="/plugin/android-emulator/help-deviceDefinition.html">


### PR DESCRIPTION
Downstream of #151. Remove usages of Prototype in favor of the new API introduced in https://github.com/jenkinsci/jenkins/pull/8008 (2.406) and subsequently corrected in https://github.com/jenkinsci/jenkins/pull/8100 (2.410).