### PR TITLE
Test with Java 21, dependencies clean-up and modernization.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,10 @@
-#!/usr/bin/env groovy
-
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin(useContainerAgent: true, configurations: [
-  [platform: 'linux',   jdk: 21], // Linux first for coverage report on ci.jenkins.io
-  [platform: 'linux', jdk: 17],
-  [platform: 'windows', jdk: 11],
-])
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+        useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+        configurations: [
+                [platform: 'linux', jdk: 21],
+                [platform: 'windows', jdk: 17],
+        ])

--- a/pom.xml
+++ b/pom.xml
@@ -83,11 +83,6 @@
             <version>3.24.2</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-cps</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,9 @@
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>matrix-project</artifactId>
+            <artifactId>port-allocator</artifactId>
+            <version>1.10</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.dongliu</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,12 +88,6 @@
             <artifactId>workflow-cps</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-cps</artifactId>
-            <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,10 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.dongliu</groupId>
             <artifactId>apk-parser</artifactId>
             <version>2.6.10</version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,12 +59,6 @@
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>port-allocator</artifactId>
-            <version>1.10</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -99,16 +99,6 @@
             <artifactId>pipeline-stage-step</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-job</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-durable-task-step</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -94,11 +94,6 @@
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>pipeline-stage-step</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <revision>3.1.5</revision>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.410</jenkins.version>
+        <jenkins.version>2.401.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 
@@ -107,11 +107,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-basic-steps</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Test with Java 21
==

Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is shallow. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Testing done
===

Confirmed tests pass with Java 21 after upgrading to a recent parent POM and to Jenkins version 2.361.4 as the minimum version.