### PR TITLE
Test with aarch64

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@
  https://github.com/jenkins-infra/pipeline-library/
 */
 buildPlugin(
-        useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+        useContainerAgent: false, // Set to `false` if you need to use Docker for containerized tests
         configurations: [
-                [platform: 'linux', jdk: 21],
+                [platform: 'arm64linux', jdk: 21],
                 [platform: 'windows', jdk: 17],
         ])


### PR DESCRIPTION
This would be the very first test with `aarch64`.
The first step is to know if this plugin can be built on `aarch64` (spoiler alert, it can).
The second step is to know if this plugin can be built on Jenkins's infra `aarch64`.
The third step is to know if this plugin can be built in a container on Jenkins's infra `aarch64`.

### Testing done

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue