### PR TITLE
Fix 'escape-by-default' XML PI

### DIFF
--- a/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/config.jelly
@@ -1,4 +1,4 @@
-<?jelly escape-by-default=true?>
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:rh="/com/redhat/jenkins/plugins/ci/form">
 
   <f:radioBlock name="android-emulator.useNamed" value="true"

--- a/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/global.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/AndroidEmulator/global.jelly
@@ -1,4 +1,4 @@
-<?jelly escape-by-default=true?>
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
   <f:section title="${%Android}">

--- a/src/main/resources/hudson/plugins/android_emulator/InstallBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/InstallBuilder/config.jelly
@@ -1,4 +1,4 @@
-<?jelly escape-by-default=true?>
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
     <f:entry title="${%APK file}">

--- a/src/main/resources/hudson/plugins/android_emulator/UninstallBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/UninstallBuilder/config.jelly
@@ -1,4 +1,4 @@
-<?jelly escape-by-default=true?>
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
     <f:entry title="${%Package ID}">

--- a/src/main/resources/hudson/plugins/android_emulator/monkey/MonkeyAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/monkey/MonkeyAction/summary.jelly
@@ -1,4 +1,4 @@
-<?jelly escape-by-default=true?>
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 
     <t:summary icon="/plugin/android-emulator/icons/${it.resultIcon}">

--- a/src/main/resources/hudson/plugins/android_emulator/monkey/MonkeyBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/monkey/MonkeyBuilder/config.jelly
@@ -1,4 +1,4 @@
-<?jelly escape-by-default=true?>
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
     <f:entry title="${%Package IDs}">

--- a/src/main/resources/hudson/plugins/android_emulator/monkey/MonkeyRecorder/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/monkey/MonkeyRecorder/config.jelly
@@ -1,4 +1,4 @@
-<?jelly escape-by-default=true?>
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
     <f:entry title="${%Filename}">

--- a/src/main/resources/hudson/plugins/android_emulator/snapshot/SnapshotLoadBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/snapshot/SnapshotLoadBuilder/config.jelly
@@ -1,4 +1,4 @@
-<?jelly escape-by-default=true?>
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
     <f:entry title="${%Snapshot name}">

--- a/src/main/resources/hudson/plugins/android_emulator/snapshot/SnapshotSaveBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/android_emulator/snapshot/SnapshotSaveBuilder/config.jelly
@@ -1,4 +1,4 @@
-<?jelly escape-by-default=true?>
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
     <f:entry title="${%Snapshot name}">

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
-<?jelly escape-by-default=true?>
+<?jelly escape-by-default='true'?>
 <div>
   Starts an Android emulator with given properties before a build, then shuts it down after.
 </div>


### PR DESCRIPTION
Use a format supported by https://github.com/jenkinsci/jelly/blob/6490f7657f03cb04bc70a06949d912fef45d87de/core/src/main/java/org/apache/commons/jelly/parser/XMLParser.java#L848-L857 for the Jelly XML PI.

This looks scary, but is just a little code cleanup: Since https://www.jenkins.io/blog/2018/10/10/security-updates/ Jelly escapes JEXL expressions by default, so this has no effect. (These views also have no unescaped top-level variable use containing user data, so not a problem even before then.)

(Why did `InjectedTest` not notice this? https://github.com/jenkinsci/jenkins-test-harness/blob/0622967429467042ee9e0ddf560716a529617755/src/main/java/org/jvnet/hudson/test/JellyTestSuiteBuilder.java#L105 is more lax than the Jelly code linked above.)

### Testing done

None

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
