### PR TITLE
Update Android SDK command line tools to version 12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,3 @@ Provides numerous features for [Android development](http://developer.android.co
 
 For more information, visit the wiki page:  
 <https://wiki.jenkins-ci.org/display/JENKINS/Android+Emulator+Plugin>
-
-## Seeking New Maintainer
-Due to time constraints, other commitments, and the values of the Jenkins project not aligning with my own, I am seeking 
-a new maintainer. Create a ticket on https://issues.jenkins-ci.org/ if interested and/or follow the guidance in 
-https://www.jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/ if you're interested in becoming the maintainer of the plugin.

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Android+Emulator+Plugin</url>
 
     <properties>
-        <revision>3.1.5</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <jenkins.baseline>2.479</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.1</jenkins.version>

--- a/src/main/java/jenkins/plugin/android/emulator/sdk/cli/SDKManagerCLIBuilder.java
+++ b/src/main/java/jenkins/plugin/android/emulator/sdk/cli/SDKManagerCLIBuilder.java
@@ -246,7 +246,7 @@ public class SDKManagerCLIBuilder {
 
         arguments.add(ARG_INSTALL);
         for (String p : packages) {
-            arguments.addQuoted(p);
+            arguments.add(p);
         }
 
         EnvVars env = new EnvVars();

--- a/src/main/java/jenkins/plugin/android/emulator/tools/AndroidSDKInstaller.java
+++ b/src/main/java/jenkins/plugin/android/emulator/tools/AndroidSDKInstaller.java
@@ -166,7 +166,7 @@ public class AndroidSDKInstaller extends DownloadFromUrlInstaller {
         }
     }
 
-    private void installBasePackages(FilePath sdkRoot, TaskListener log) throws IOException, InterruptedException {
+    private void installBasePackages(FilePath sdkRoot, @NonNull TaskListener log) throws IOException, InterruptedException {
         FilePath sdkmanager = sdkRoot.child("tools").child("bin").child("sdkmanager" + platform.extension);
         if (!sdkmanager.exists()) {
             sdkmanager = sdkRoot.child("cmdline-tools").child("bin").child("sdkmanager" + platform.extension);
@@ -193,7 +193,7 @@ public class AndroidSDKInstaller extends DownloadFromUrlInstaller {
                     }
                     return defaultPackage.equals(i.getId());
                 })) //
-                .collect(Collectors.toList());
+                .toList();
 
         if (!defaultPackages.isEmpty()) {
             // get component with the available latest version
@@ -210,7 +210,9 @@ public class AndroidSDKInstaller extends DownloadFromUrlInstaller {
                     // remove release candidate versions for stable channel
                     .filter(p -> channel != Channel.STABLE || p.getVersion().getQualifier() == null) //
                     .sorted(Collections.reverseOrder()) // in case of wildcards we takes latest version
-                    .findFirst().get().getId()));
+                    .findFirst()
+                    .get()
+                    .getId()));
 
             SDKManagerCLIBuilder.with(sdkmanager) //
                     .proxy(Jenkins.get().proxy) //

--- a/src/main/java/jenkins/plugin/android/emulator/tools/Platform.java
+++ b/src/main/java/jenkins/plugin/android/emulator/tools/Platform.java
@@ -35,7 +35,7 @@ import jenkins.plugin.android.emulator.Messages;
  * Supported platform.
  */
 public enum Platform {
-    LINUX(".sh", "bin"), WINDOWS(".bat", "bin"), OSX(".sh", "bin");
+    LINUX("", "bin"), WINDOWS(".bat", "bin"), OSX(".sh", "bin");
 
     /**
      * Choose the extension file name suitable to run cli commands.

--- a/src/main/resources/jenkins.plugin.android.emulator.tools.AndroidSDKInstaller.json
+++ b/src/main/resources/jenkins.plugin.android.emulator.tools.AndroidSDKInstaller.json
@@ -1,6 +1,11 @@
 {
   "list": [
     {
+      "id": "cmdline-tools:12.0",
+      "url": "https://dl.google.com/android/repository/commandlinetools-{os}-11076708_latest.zip",
+      "name": "Command-line Tools 12.0"
+    },
+    {
       "id": "cmdline-tools:4.0",
       "url": "https://dl.google.com/android/repository/commandlinetools-{os}-7302050_latest.zip",
       "name": "Command-line Tools 4.0"


### PR DESCRIPTION
This pull request fixes the sdkmanager component installation removing the double quotes from CLI arguments that cause issue in jenkins linux node.
Fix executable file name for linux environments

### Testing done
Installed commands 12.0 tool under windows and linux

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue